### PR TITLE
Add readonly attributes to inspect TextDecoder's properties: ignoreBOM flag and fatal flag

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1048,7 +1048,6 @@ control.
  <dt><code><var title>ignoreBOM</var> . <span title=dom-TextDecoder-ignoreBOM>ignoreBOM</span></code>
  <dd><p>Returns true if the <b>ignore BOM flag</b> is set, and returns false otherwise</span>.
 
-
  <dt><code><var title>decoder</var> . <span title=dom-TextDecoder-decode>decode</span>([<var title>input</var> [, <var title>options</var>]])</code>
  <dd>
   <p>Returns the result of running <b>encoding</b>'s


### PR DESCRIPTION
Per F2F discussion, the flags that TextDecoder was created with should probably be exposed to script.

Note that this PR just changes `Overview.src.html`; someone with the toolchain installed will need to run "make" to update `Overview.html`
