### PR TITLE
Closes issue 5: Test _code point_ instead of _pointer_ for null when prepending ASCII byte.

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1749,7 +1749,7 @@ consumers of content generated with <span>gbk</span>'s <span>encoder</span>.
    <var title>pointer</var> is null and the <span>index code point</span>
    for <var title>pointer</var> in <span>index big5</span> otherwise.
 
-   <li><p>If <var title>pointer</var> is null and <var title>byte</var> is in the range
+   <li><p>If <var title>code point</var> is null and <var title>byte</var> is in the range
    0x00 to 0x7F, <span title=concept-stream-prepend>prepend</span> <var title>byte</var>
    to <var>stream</var>.
 


### PR DESCRIPTION
Fix https://github.com/whatwg/encoding/issues/5