### PR TITLE
Make the name of ISO-8859-8-I all upper case in encodings.json.

### DIFF
--- a/encodings.json
+++ b/encodings.json
@@ -136,7 +136,7 @@
           "iso-8859-8-i",
           "logical"
         ],
-        "name": "ISO-8859-8-i"
+        "name": "ISO-8859-8-I"
       },
       {
         "labels": [


### PR DESCRIPTION
Looks like a find-and-replace oversight.