### PR TITLE
Export the algorithms intended for use by other specs.

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -855,7 +855,7 @@ to represent ranges.)
 <span title=concept-encoding-get>get an encoding</span> algorithm can be used first to turn a
 <span>label</span> into an <span>encoding</span>.
 
-<p>To <dfn>decode</dfn> a byte stream <var>stream</var> using
+<p>To <dfn data-export>decode</dfn> a byte stream <var>stream</var> using
 fallback encoding <var>encoding</var>, run these steps:
 
 <ol>
@@ -901,7 +901,7 @@ fallback encoding <var>encoding</var>, run these steps:
  <li><p>Return <var>output</var>.
 </ol>
 
-<p>To <dfn>UTF-8 decode</dfn> a byte stream <var>stream</var>, run
+<p>To <dfn data-export>UTF-8 decode</dfn> a byte stream <var>stream</var>, run
 these steps:
 
 <ol>
@@ -921,7 +921,7 @@ these steps:
  <li><p>Return <var>output</var>.
 </ol>
 
-<p>To <dfn>UTF-8 decode without BOM</dfn> a byte stream <var>stream</var>, run these
+<p>To <dfn data-export>UTF-8 decode without BOM</dfn> a byte stream <var>stream</var>, run these
 steps:
 
 <ol>
@@ -933,7 +933,7 @@ steps:
  <li><p>Return <var>output</var>.
 </ol>
 
-<p>To <dfn>UTF-8 decode without BOM or fail</dfn> a byte stream <var>stream</var>, run these steps:
+<p>To <dfn data-export>UTF-8 decode without BOM or fail</dfn> a byte stream <var>stream</var>, run these steps:
 
 <ol>
  <li><p>Let <var>output</var> be a code point stream.
@@ -949,7 +949,7 @@ steps:
 
 <hr>
 
-<p>To <dfn>encode</dfn> a code point stream <var>stream</var> using
+<p>To <dfn data-export>encode</dfn> a code point stream <var>stream</var> using
 encoding <var>encoding</var>, run these steps:
 
 <ol>
@@ -970,7 +970,7 @@ encoding <var>encoding</var>, run these steps:
 <span data-anolis-ref class=informative>URL</span>
 <span data-anolis-ref class=informative>HTML</span>
 
-<p>To <dfn>UTF-8 encode</dfn> a code point stream <var>stream</var>,
+<p>To <dfn data-export>UTF-8 encode</dfn> a code point stream <var>stream</var>,
 return the result of <span title=encode>encoding</span>
 <var>stream</var> using encoding <span>UTF-8</span>.
 


### PR DESCRIPTION
Using the `<dfn>` format defined at
https://github.com/tabatkins/bikeshed/blob/master/docs/dfn-contract.md.

http://anolis.hoppipolla.co.uk/aquarium.py fails on this file because it contains a non-ascii comment (&#x01f4a9;), so I haven't tested that it actually produces the right output.