### PR TITLE
Encourage implementations to avoid copying in TextDecoder

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -1190,9 +1190,14 @@ method, when invoked, must run these steps:
  <a for=TextDecoder>do not flush flag</a>, and unset the <a for=TextDecoder>do not flush flag</a>
  otherwise.
 
- <li><p>If <var>input</var> is given, <a>push</a> a
- <a lt="get a copy of the buffer source">copy of</a>
- <var>input</var> to <a for=TextDecoder>stream</a>.
+ <li>
+  <p>If <var>input</var> is given, then <a>push</a> a
+  <a lt="get a copy of the buffer source">copy of</a> <var>input</var> to
+  <a for=TextDecoder>stream</a>.
+
+  <p class=note>Implementations are strongly encouraged to use an implementation strategy that
+  avoids this copy. When doing so they will have to make sure that changes to <var>input</var> do
+  not affect future calls to <a method><code>decode()</code></a>.
 
  <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
 


### PR DESCRIPTION
Fixes #92.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://encoding.spec.whatwg.org/branch-snapshots/annevk/avoid-copy/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/encoding/ee2bd34...180c06f.html)