### PR TITLE
Editorial: remove floor() operation in favor of integer division

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -101,10 +101,9 @@ many reasons that is now the mandatory encoding for all things.
 <p>Hexadecimal numbers are prefixed with "0x".
 
 <p>In equations, all numbers are integers, addition is represented by "+", subtraction by "&minus;",
-multiplication by "×", division by "/", calculating the remainder of a division (also known as
-modulo) by "%", logical left shifts by "&lt;&lt;", logical right shifts by ">>", bitwise AND by
-"&amp;", and bitwise OR by "|". floor(<var>x</var>) is the largest integer not greater than
-<var>x</var>.
+multiplication by "×", integer division by "/" (returns the quotient), modulo by "%" (returns the
+remainder of an integer division), logical left shifts by "&lt;&lt;", logical right shifts by ">>",
+bitwise AND by "&amp;", and bitwise OR by "|".
 
 <p>For logical right shifts operands must have at least twenty-one bits precision.
 
@@ -1726,7 +1725,7 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
   <p>If <var>pointer</var> is not null, run these substeps:
 
   <ol>
-   <li><p>Let <var>lead</var> be floor(<var>pointer</var> / 190) + 0x81.
+   <li><p>Let <var>lead</var> be <var>pointer</var> / 190 + 0x81.
 
    <li><p>Let <var>trail</var> be <var>pointer</var> % 190.
 
@@ -1743,15 +1742,15 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
  <li><p>Set <var>pointer</var> to the
  <a>index gb18030 ranges pointer</a> for <var>code point</var>.
 
- <li><p>Let <var>byte1</var> be floor(<var>pointer</var> / (10 × 126 × 10)).
+ <li><p>Let <var>byte1</var> be <var>pointer</var> / (10 × 126 × 10).
 
  <li><p>Set <var>pointer</var> to <var>pointer</var> % (10 × 126 × 10).
 
- <li><p>Let <var>byte2</var> be floor(<var>pointer</var> / (10 × 126)).
+ <li><p>Let <var>byte2</var> be <var>pointer</var> / (10 × 126).
 
  <li><p>Set <var>pointer</var> to <var>pointer</var> % (10 × 126).
 
- <li><p>Let <var>byte3</var> be floor(<var>pointer</var> / 10).
+ <li><p>Let <var>byte3</var> be <var>pointer</var> / 10.
 
  <li><p>Let <var>byte4</var> be <var>pointer</var> % 10.
 
@@ -1859,7 +1858,7 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
  <li><p>If <var>pointer</var> is null, return <a>error</a> with
  <var>code point</var>.
 
- <li><p>Let <var>lead</var> be floor(<var>pointer</var> / 157) + 0x81.
+ <li><p>Let <var>lead</var> be <var>pointer</var> / 157 + 0x81.
 
  <li><p>Let <var>trail</var> be <var>pointer</var> % 157.
 
@@ -1970,7 +1969,7 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
  <li><p>If <var>pointer</var> is null, return <a>error</a> with
  <var>code point</var>.
 
- <li><p>Let <var>lead</var> be floor(<var>pointer</var> / 94) + 0xA1.
+ <li><p>Let <var>lead</var> be <var>pointer</var> / 94 + 0xA1.
 
  <li><p>Let <var>trail</var> be <var>pointer</var> % 94 + 0xA1.
 
@@ -2283,7 +2282,7 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
  <a lt="iso 2022 jp encoder jis0208">jis0208</a>, and return three bytes
  0x1B 0x24 0x42.
 
- <li><p>Let <var>lead</var> be floor(<var>pointer</var> / 94) + 0x21.
+ <li><p>Let <var>lead</var> be <var>pointer</var> / 94 + 0x21.
 
  <li><p>Let <var>trail</var> be <var>pointer</var> % 94 + 0x21.
 
@@ -2390,7 +2389,7 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
  <li><p>If <var>pointer</var> is null, return <a>error</a> with
  <var>code point</var>.
 
- <li><p>Let <var>lead</var> be floor(<var>pointer</var> / 188).
+ <li><p>Let <var>lead</var> be <var>pointer</var> / 188.
 
  <li><p>Let <var>lead offset</var> be 0x81, if <var>lead</var> is
  less than 0x1F, and 0xC1 otherwise.
@@ -2479,7 +2478,7 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
  <li><p>If <var>pointer</var> is null, return <a>error</a> with
  <var>code point</var>.
 
- <li><p>Let <var>lead</var> be floor(<var>pointer</var> / 190) + 0x81.
+ <li><p>Let <var>lead</var> be <var>pointer</var> / 190 + 0x81.
 
  <li><p>Let <var>trail</var> be <var>pointer</var> % 190 + 0x41.
 


### PR DESCRIPTION
Fixes #66.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://encoding.spec.whatwg.org/branch-snapshots/annevk/roof/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/encoding/ee2bd34...7eba85a.html)