### PR TITLE
Use HTML checker network API + suppress warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,11 @@ language: generic
 
 env:
   global:
-    - ENCRYPTION_LABEL: "eaa0f98d3fae"
-addons:
-  apt:
-    packages:
-      - oracle-java8-set-default
-install:
-  - curl -O https://sideshowbarker.net/nightlies/jar/vnu.jar
+    - ENCRYPTION_LABEL="eaa0f98d3fae"
+    - DEPLOY_USER="annevankesteren"
+    - CHECKER_PARAMS='\&filterpattern=Text%20run%20is%20not%20in%20Unicode%20Normalization%20Form%20C\.|.*appears%20to%20be%20written%20in.*|.*Charmod%20C073.*'
 script:
   - bash ./deploy.sh
-  - /usr/lib/jvm/java-8-oracle/jre/bin/java -jar vnu.jar --skip-non-html /home/travis/build/whatwg/encoding
 notifications:
   email:
     on_success: never

--- a/deploy.sh
+++ b/deploy.sh
@@ -89,7 +89,14 @@ echo ""
 find $WEB_ROOT -print
 echo ""
 
-if [ "$1" != "--local" ]; then
+if [ "$TRAVIS" == "true" ]; then
+    # Run the HTML checker only when building on Travis
+    (find $WEB_ROOT -name "*.html" -exec bash -c 'echo "Checking {}..."; \
+      curl -s -H "Content-Type: text/html; charset=utf-8" \
+        --data-binary @{} \
+        https://checker.html5.org/?out=gnu\&file={}$CHECKER_PARAMS \
+      | tee -a OUTPUT; echo' \;); if [ -s OUTPUT ]; then exit 1; fi
+
     # Get the deploy key by using Travis's stored variables to decrypt deploy_key.enc
     ENCRYPTED_KEY_VAR="encrypted_${ENCRYPTION_LABEL}_key"
     ENCRYPTED_IV_VAR="encrypted_${ENCRYPTION_LABEL}_iv"


### PR DESCRIPTION
* Switch to using the HTML checker network API rather than `vnu.jar`
* Add a `CHECKER_PARAMS` environment variable to `.travis.yml` to cause the
  HTML checker to suppress warnings about Unicode non-NFC text runs and also
  about use of Unicode Private Use area, and about missing `html[lang]`
