### PR TITLE
EUC-JP: only unwind ASCII bytes

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -1923,8 +1923,7 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
 
    <li><p>Unset the <a>EUC-JP jis0212 flag</a>.
 
-   <li><p>If <var>byte</var> is not in the range 0xA1 to 0xFE, inclusive,
-   <a>prepend</a> <var>byte</var> to
+   <li><p>If <var>byte</var> is an <a>ASCII byte</a>, <a>prepend</a> <var>byte</var> to
    <var>stream</var>.
 
    <li><p>If <var>code point</var> is null, return <a>error</a>.


### PR DESCRIPTION
See https://github.com/whatwg/encoding/issues/59#issuecomment-297750352
for context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://encoding.spec.whatwg.org/branch-snapshots/annevk/euc-jp-ascii/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/encoding/612f9c6...b3bbc1b.html)