### PR TITLE
Meta: retry HTML checker by curl, suppress warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,10 @@ language: generic
 
 env:
   global:
-    - ENCRYPTION_LABEL: "eaa0f98d3fae"
-addons:
-  apt:
-    packages:
-      - oracle-java8-set-default
-install:
-  - curl -O https://sideshowbarker.net/nightlies/jar/vnu.jar
+    - ENCRYPTION_LABEL="eaa0f98d3fae"
+    - CHECKER_PARAMS='\&filterpattern=Text%20run%20is%20not%20in%20Unicode%20Normalization%20Form%20C\.\|.*appears%20to%20be%20written%20in.*\|.*Charmod%20C073.*'
 script:
   - bash ./deploy.sh
-  - /usr/lib/jvm/java-8-oracle/jre/bin/java -jar vnu.jar --skip-non-html /home/travis/build/whatwg/encoding
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
This restores 9ce8d47 but refines such that if curl hits a timeout, it
will automatically retry each request up to 7 times.

From the curl(1) man page:

> --retry <num>
>    If  a  transient  error is returned when curl tries to perform a
>    transfer, it will retry this number of times before  giving  up.
>    Setting  the  number to 0 makes curl do no retries (which is the
>    default). Transient error means either: a timeout,  an  FTP  4xx
>    response code or an HTTP 5xx response code.
>
>    When  curl  is about to retry a transfer, it will first wait one
>    second and then for all forthcoming retries it will  double  the
>    waiting  time until it reaches 10 minutes which then will be the
>    delay between the rest of the retries.

Addresses #97


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://encoding.spec.whatwg.org/branch-snapshots/sideshowbarker/checker-via-curl-retry/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/encoding/eedd518...19aa804.html)