### PR TITLE
gb18030 decoder: unwind from fourth byte when it's not a digit

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -1641,11 +1641,13 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
    <li><p>Set <a>gb18030 first</a>, <a>gb18030 second</a>, and
    <a>gb18030 third</a> to 0x00.
 
-   <li><p>If <var>code point</var> is null,
-   <a>prepend</a> <var>buffer</var> to
-   <var>stream</var> and return <a>error</a>.
+   <li><p>If <var>code point</var> is non-null, return a code point whose value is
+   <var>code point</var>.
 
-   <li><p>Return a code point whose value is <var>code point</var>.
+   <li><p>If <var>byte</var> is not in the range 0x30 to 0x39, inclusive, <a>prepend</a>
+   <var>buffer</var> to <var>stream</var>.
+
+   <li><p>Return <a>error</a>.
   </ol>
 
  <li>

--- a/encoding.bs
+++ b/encoding.bs
@@ -1625,29 +1625,26 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
   <p>If <a>gb18030 third</a> is not 0x00, then:
 
   <ol>
-   <li><p>Let <var>code point</var> be null.
+   <li>
+    <p>If <var>byte</var> is not in the range 0x30 to 0x39, inclusive, then:
 
-   <li><p>If <var>byte</var> is in the range 0x30 to 0x39, inclusive, set
-   <var>code point</var> to the
-   <a>index gb18030 ranges code point</a> for
+    <ol>
+     <li><p><a>Prepend</a> <a>gb18030 second</a>, <a>gb18030 third</a>, and <var>byte</var> to
+     <var>stream</var>.
+
+     <li><p>Set <a>gb18030 first</a>, <a>gb18030 second</a>, and <a>gb18030 third</a> to 0x00.
+
+     <li><p>Return <a>error</a>.
+    </ol>
+
+   <li><p>Let <var>code point</var> be the <a>index gb18030 ranges code point</a> for
    ((<a>gb18030 first</a> &minus; 0x81) × (10 × 126 × 10)) +
    ((<a>gb18030 second</a> &minus; 0x30) × (10 × 126)) +
    ((<a>gb18030 third</a> &minus; 0x81) × 10) + <var>byte</var> &minus; 0x30.
 
-   <li><p>Let <var>buffer</var> be a byte sequence consisting of
-   <a>gb18030 second</a>, <a>gb18030 third</a>, and <var>byte</var>, in
-   order.
+   <li><p>If <var>code point</var> is null, return <a>error</a>.
 
-   <li><p>Set <a>gb18030 first</a>, <a>gb18030 second</a>, and
-   <a>gb18030 third</a> to 0x00.
-
-   <li><p>If <var>code point</var> is non-null, return a code point whose value is
-   <var>code point</var>.
-
-   <li><p>If <var>byte</var> is not in the range 0x30 to 0x39, inclusive, <a>prepend</a>
-   <var>buffer</var> to <var>stream</var>.
-
-   <li><p>Return <a>error</a>.
+   <li><p>Return a code point whose value is <var>code point</var>.
   </ol>
 
  <li>


### PR DESCRIPTION
Instead of always unwinding if there’s no code point when consuming the
fourth byte, only unwind when the fourth byte is not an ASCII digit.
This does mean that ASCII digits can be masked, but since ASCII digits
are not used as delimiter in any format this is highly unlikely to be
used in any attacks (and also matches existing implementations better).

Fixes #110.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://encoding.spec.whatwg.org/branch-snapshots/annevk/gb18030-fourth-byte/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/encoding/378393f...951c471.html)