### PR TITLE
Meta: TF-8 decode without BOM or fail is used at least once

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -917,7 +917,9 @@ steps:
  <li><p>Return <var>output</var>.
 </ol>
 
-<p>To <dfn export>UTF-8 decode without BOM or fail</dfn> a byte stream <var>stream</var>, run these steps:
+<p>To <dfn export>UTF-8 decode without BOM or fail</dfn> a byte stream <var>stream</var>, run these
+steps:
+<!-- https://tools.ietf.org/html/rfc6455#section-8.1 needs this. -->
 
 <ol>
  <li><p>Let <var>output</var> be a code point stream.

--- a/encoding.bs
+++ b/encoding.bs
@@ -919,7 +919,9 @@ steps:
 
 <p>To <dfn export>UTF-8 decode without BOM or fail</dfn> a byte stream <var>stream</var>, run these
 steps:
-<!-- https://tools.ietf.org/html/rfc6455#section-8.1 needs this. -->
+<!-- Needed by https://tools.ietf.org/html/rfc6455#section-8.1 and
+     https://webassembly.github.io/spec/js-api/#dom-module-customsections-moduleobject-sectionname
+     -->
 
 <ol>
  <li><p>Let <var>output</var> be a code point stream.


### PR DESCRIPTION
(Even thought it's not explicitly referenced.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/124.html" title="Last updated on Apr 25, 2018, 9:10 AM GMT (ba65a05)">Preview</a> | <a href="https://whatpr.org/encoding/124/d55cb85...ba65a05.html" title="Last updated on Apr 25, 2018, 9:10 AM GMT (ba65a05)">Diff</a>