### PR TITLE
Make TextEncoder and TextDecoder be transform streams

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -1540,8 +1540,8 @@ must run these steps:
 
  <p class=note>{{DOMString}} is used here so that a surrogate pair that is split between chunks can
  be correctly reassembled into the appropriate code point in the output. The behaviour is otherwise
- identical to {{USVString}}. In particular, replacement characters will be used where necessary to
- make the output valid UTF-8.
+ identical to {{USVString}}. In particular, lone surrogates will be replaced with U+FFFD so that the
+ output is always well-formed UTF-8.
 
  <li><p>Convert <var>input</var> to a <a for=/>stream</a>.
 

--- a/encoding.bs
+++ b/encoding.bs
@@ -1314,6 +1314,8 @@ method, when invoked, must run these steps:
   </ol>
 </ol>
 
+<hr>
+
 <p>The <dfn id=concept-td-decode-and-enqueue>decode and enqueue a chunk</dfn> algorithm, given a
 {{TextDecoder}} <var>dec</var> and a <var>chunk</var>, runs these steps:
 
@@ -1528,6 +1530,8 @@ must run these steps:
   </ol>
 </ol>
 
+<hr>
+
 <p>The <dfn id=concept-te-encode-and-enqueue>encode and enqueue a chunk</dfn> algorithm, given a
 {{TextEncoder}} <var>enc</var> and <var>chunk</var>, runs these steps:
 
@@ -1570,7 +1574,6 @@ must run these steps:
  </ol>
 </ol>
 
-
 <p>The <dfn id=concept-te-convert-code-unit-to-scalar-value>convert code unit to scalar value</dfn>
 algorithm, given a {{TextEncoder}} <var>enc</var>, <var>token</var> and <var>input</var> stream,
 runs these steps:
@@ -1603,7 +1606,6 @@ runs these steps:
 <p class=note>This is equivalent to the <a spec=webidl>convert a DOMString to a sequence of Unicode
 scalar values</a> algorithm from [[WEBIDL]], but allows for surrogate pairs that are split between
 strings.
-
 
 <p>The <dfn id=concept-te-encode-and-flush>encode and flush</dfn> algorithm, given a
 {{TextEncoder}} <var>enc</var>, runs these steps:

--- a/encoding.bs
+++ b/encoding.bs
@@ -1224,16 +1224,17 @@ constructor, when invoked, must run these steps:
  <li><p>Set <var>decForTransform</var>'s <a for=TextDecoder>ignore BOM flag</a> to <var>dec</var>'s
  <a for=TextDecoder>ignore BOM flag</a>.
 
- <li><p>Set <var>decForTransform</var>'s <a for=TextDecoder>decoder</a> to a new
- <a for=/>decoder</a> for <var>decForTransform</var>'s <a for=TextDecoder>encoding</a>, and set
- <var>decForTransform</var>'s <a for=TextDecoder>stream</a> to a new <a for=/>stream</a>.
+ <li>
+  <p>Set <var>decForTransform</var>'s <a for=TextDecoder>decoder</a> to a new <a for=/>decoder</a>
+  for <var>decForTransform</var>'s <a for=TextDecoder>encoding</a>, and set
+  <var>decForTransform</var>'s <a for=TextDecoder>stream</a> to a new <a for=/>stream</a>.
 
- <p class=note>For simplicity, <var>dec</var> and <var>decForTransform</var> have redundant
- members. However, the <a for=TextDecoder>BOM seen flag</a>, <a for=TextDecoder>do not flush
- flag</a>, and <a for=TextDecoder>transform</a> are unused in <var>decForTransform</var>, and
- <a for=TextDecoder>encoding</a>, <a for=TextDecoder>ignore BOM flag</a> and
- <a for=TextDecoder>error mode</a> are identical to <var>dec</var>. It is not necessary for
- implementations to duplicate these member fields.</p>
+  <p class=note>For simplicity, <var>dec</var> and <var>decForTransform</var> have redundant
+  members. However, the <a for=TextDecoder>BOM seen flag</a>, <a for=TextDecoder>do not flush
+  flag</a>, and <a for=TextDecoder>transform</a> are unused in <var>decForTransform</var>, and
+  <a for=TextDecoder>encoding</a>, <a for=TextDecoder>ignore BOM flag</a> and
+  <a for=TextDecoder>error mode</a> are identical to <var>dec</var>. It is not necessary for
+  implementations to duplicate these member fields.
 
  <li><p>Let <var>startAlgorithm</var> be an algorithm that takes no arguments and returns nothing.
 
@@ -1462,13 +1463,14 @@ constructor, when invoked, must run these steps:
 
  <li><p>Let <var>encForTransform</var> be a new {{TextEncoder}} object.
 
- <li><p>Set <var>encForTransform</var>'s <a for=TextEncoder>encoder</a> to <a>UTF-8</a>'s
- <a for=/>encoder</a>.
+ <li>
+  <p>Set <var>encForTransform</var>'s <a for=TextEncoder>encoder</a> to <a>UTF-8</a>'s
+  <a for=/>encoder</a>.
 
- <p class=note>For simplicity, <var>enc</var> and <var>encForTransform</var> have the same
- members. However, <a for=TextEncoder>transform</a> is not used by <var>encForTransform</var>
- and <a for=TextEncoder>pending high surrogate</a> is not used by <var>enc</var>. It is not
- necessary for implementations to store these unused member fields.</p>
+  <p class=note>For simplicity, <var>enc</var> and <var>encForTransform</var> have the same
+  members. However, <a for=TextEncoder>transform</a> is not used by <var>encForTransform</var> and
+  <a for=TextEncoder>pending high surrogate</a> is not used by <var>enc</var>. It is not necessary
+  for implementations to store these unused member fields.
 
  <li><p>Let <var>startAlgorithm</var> be an algorithm that takes no arguments and returns nothing.
 
@@ -1621,14 +1623,10 @@ between strings.
    <li><p>Let <var>controller</var> be <var>encForTransform</var>'s
    <a for=TextEncoder>transform</a>.\[[transformStreamController]].
 
-   <li><p>Let <var>token</var> be U+FFFD.
+   <li>
+    <p>Let <var>output</var> be the byte sequence 0xEF 0xBF 0xBD.
 
-   <li><p>Let <var>input</var> and <var>output</var> be new <a for=/>stream</a>s.
-
-   <li><p><a>Process</a> <var>token</var> for <a for=TextEncoder>encoder</a>, <var>input</var>,
-   <var>output</var>.
-
-   <li><p>Convert <var>output</var> into a byte sequence.
+    <p class=note>This is the replacement character U+FFFD encoded as UTF-8.
 
    <li><p>Let <var>chunk</var> be a {{Uint8Array}} object wrapping an {{ArrayBuffer}} containing
    <var>output</var>.

--- a/encoding.bs
+++ b/encoding.bs
@@ -1214,13 +1214,35 @@ constructor, when invoked, must run these steps:
  <li><p>If <var>options</var>'s <code>ignoreBOM</code> member is true, then set <var>dec</var>'s
  <a for=TextDecoder>ignore BOM flag</a>.
 
+ <li><p>Let <var>decForTransform</var> be a new {{TextDecoder}} object.
+
+ <li><p>Set <var>decForTransform</var>'s <a for=TextDecoder>encoding</a> to <var>encoding</var>.
+
+ <li><p>Set <var>decForTransform</var>'s <a for=TextDecoder>error mode</a> to <var>dec</var>'s
+ <a for=TextDecoder>error mode</a>.
+
+ <li><p>Set <var>decForTransform</var>'s <a for=TextDecoder>ignore BOM flag</a> to <var>dec</var>'s
+ <a for=TextDecoder>ignore BOM flag</a>.
+
+ <li><p>Set <var>decForTransform</var>'s <a for=TextDecoder>decoder</a> to a new <a
+ for=/>decoder</a> for <var>decForTransform</var>'s <a for=TextDecoder>encoding</a>, and set
+ <var>decForTransform</var>'s <a for=TextDecoder>stream</a> to a new <a for=/>stream</a>.
+
+ <p class=note>For simplicity, <var>dec</var> and <var>decForTransform</var> have redundant
+ members. However, the <a for=TextDecoder>BOM seen flag</a>, <a for=TextDecoder>do not flush
+ flag</a>, and <a for=TextDecoder>transform</a> are unused in <var>decForTransform</var>, and <a
+ for=TextDecoder>encoding</a>, <a for=TextDecoder>ignore BOM flag</a> and <a for=TextDecoder>error
+ mode</a> are identical to <var>dec</var>. It is not necessary for implementations to duplicate
+ these member fields.</p>
+
  <li><p>Let <var>startAlgorithm</var> be an algorithm that takes no arguments and returns nothing.
 
  <li><p>Let <var>transformAlgorithm</var> be an algorithm which takes a <var>chunk</var> argument
- and runs the <a>decode and enqueue a chunk</a> algorithm with <var>dec</var> and <var>chunk</var>.
+ and runs the <a>decode and enqueue a chunk</a> algorithm with <var>decForTransform</var> and
+ <var>chunk</var>.
 
  <li><p>Let <var>flushAlgorithm</var> be an algorithm which takes no arguments and runs the <a>flush
- and enqueue</a> algorithm with <var>dec</var>.
+ and enqueue</a> algorithm with <var>decForTransform</var>.
 
  <li><p>Let <var>transform</var> be the result of calling
  <a abstract-op>CreateTransformStream</a>(<var>startAlgorithm</var>, <var>transformAlgorithm</var>,
@@ -1250,19 +1272,6 @@ true if <a for=TextDecoder>ignore BOM flag</a> is set, and false otherwise.
 method, when invoked, must run these steps:
 
 <ol>
- <li><p>Let <var>readable</var> be <a for=TextDecoder>transform</a>.\[[readable]].
-
- <li><p>If <a abstract-op>IsReadableStreamLocked</a>(<var>readable</var>) is true, then throw a
- {{TypeError}} exception.
-
- <li><p>Let <var>writable</var> be <a for=TextDecoder>transform</a>.\[[writable]].
-
- <li><p>If <a abstract-op>IsWritableStreamLocked</a>(<var>writable</var>) is true, then throw a
- {{TypeError}} exception.
-
- <p class="note">These steps ensure that the state of the <a for=/>decoder</a> is not simultaneously
- modified by the Streams API and this method.
-
  <li><p>If the <a for=TextDecoder>do not flush flag</a> is unset, set <a for=TextDecoder>decoder</a>
  to a new <a for=TextDecoder>encoding</a>'s <a for=/>decoder</a>, set <a for=TextDecoder>stream</a>
  to a new <a for=/>stream</a>, and unset the <a for=TextDecoder>BOM seen flag</a>.
@@ -1317,7 +1326,7 @@ method, when invoked, must run these steps:
 <hr>
 
 <p>The <dfn id=concept-td-decode-and-enqueue>decode and enqueue a chunk</dfn> algorithm, given a
-{{TextDecoder}} <var>dec</var> and a <var>chunk</var>, runs these steps:
+{{TextDecoder}} <var>decForTransform</var> and a <var>chunk</var>, runs these steps:
 
 <ol>
  <li><p>If <a>Type</a>(<var>chunk</var>) is not Object, or <var>chunk</var> does not have an
@@ -1325,17 +1334,10 @@ method, when invoked, must run these steps:
  true, or <a abstract-op>IsSharedArrayBuffer</a>(<var>chunk</var>) is true, then return a new
  promise rejected with a {{TypeError}} exception.
 
- <li><p>If the <a for=TextDecoder>do not flush flag</a> for <var>dec</var> is unset, then set
- <var>dec's</var> <a for=TextDecoder>decoder</a> to a new <a for=/>decoder</a> for <var>dec</var>'s
- <a for=TextDecoder>encoding</a>, set <var>dec</var>'s <a for=TextDecoder>stream</a> to a new
- <a for=/>stream</a>, and unset <var>dec</var>'s <a for=TextDecoder>BOM seen flag</a>.
-
- <li><p>Set <var>dec</var>'s <a for=TextDecoder>do not flush flag</a>.
-
  <li><p><a>Push</a> a <a lt="get a copy of the buffer source">copy of</a> <var>chunk</var> to
- <var>dec</var>'s <a for=TextDecoder>stream</a>.
+ <var>decForTransform</var>'s <a for=TextDecoder>stream</a>.
 
- <li><p>Let <var>controller</var> be <var>dec</var>'s
+ <li><p>Let <var>controller</var> be <var>decForTransform</var>'s
  <a for=TextDecoder>transform</a>.\[[transformStreamController]].
 
  <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
@@ -1344,7 +1346,7 @@ method, when invoked, must run these steps:
   <p>While true, run these steps:
 
   <ol>
-   <li><p>Let <var>token</var> be the result of <a>reading</a> from <var>dec</var>'s
+   <li><p>Let <var>token</var> be the result of <a>reading</a> from <var>decForTransform</var>'s
    <a for=TextDecoder>stream</a>.
 
    <li>
@@ -1360,8 +1362,9 @@ method, when invoked, must run these steps:
     </ol>
 
    <li><p>Let <var>result</var> be the result of <a>processing</a> <var>token</var> for
-   <var>dec</var>'s <a for=TextDecoder>decoder</a>, <var>dec</var>'s <a for=TextDecoder>stream</a>,
-   <var>output</var>, and <var>dec's</var> <a for=TextDecoder>error mode</a>.
+   <var>decForTransform</var>'s <a for=TextDecoder>decoder</a>, <var>decForTransform</var>'s <a
+   for=TextDecoder>stream</a>, <var>output</var>, and <var>decForTransform</var>'s <a
+   for=TextDecoder>error mode</a>.
 
    <li><p>If <var>result</var> is <a>error</a>, then return a new promise rejected with a
    {{TypeError}} exception.
@@ -1369,27 +1372,22 @@ method, when invoked, must run these steps:
 </ol>
 
 <p>The <dfn id=concept-td-flush-and-enqueue>flush and enqueue</dfn> algorithm, which handles the end
-of data from the input {{ReadableStream}}, given a {{TextDecoder}} <var>dec</var>, runs these steps:
+of data from the input {{ReadableStream}}, given a {{TextDecoder}} <var>decForTransform</var>, runs
+these steps:
 
 <ol>
- <li><p>If the <a for=TextDecoder>do not flush flag</a> for <var>dec</var> is unset, then set
- <var>dec's</var> <a for=TextDecoder>decoder</a> to a new <a for=/>decoder</a> for <var>dec</var>'s
- <a for=TextDecoder>encoding</a>, set <var>dec</var>'s <a for=TextDecoder>stream</a> to a new
- <a for=/>stream</a>, and unset <var>dec</var>'s <a for=TextDecoder>BOM seen flag</a>.
-
- <li><p>Unset <var>dec</var>'s <a for=TextDecoder>do not flush flag</a>.
-
  <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
 
  <li><p>Let <var>result</var> be the result of <a>processing</a> <a>end-of-stream</a> for
- <var>dec</var>'s <a for=TextDecoder>decoder</a> and <var>dec</var>'s <a for=TextDecoder>stream</a>,
- <var>output</var>, and <var>dec</var>'s <a for=TextDecoder>error mode</a>.
+ <var>decForTransform</var>'s <a for=TextDecoder>decoder</a> and <var>decForTransform</var>'s <a
+ for=TextDecoder>stream</a>, <var>output</var>, and <var>decForTransform</var>'s <a
+ for=TextDecoder>error mode</a>.
 
  <li><p>If <var>result</var> is <a>finished</a>, then run these steps:
  <ol>
   <li><p>Let <var>outputChunk</var> be <var>output</var>, <a lt="serialize stream">serialized</a>.
 
-  <li><p>Let <var>controller</var> be <var>dec</var>'s
+  <li><p>Let <var>controller</var> be <var>decForTransform</var>'s
   <a for=TextDecoder>transform</a>.\[[transformStreamController]].
 
   <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>,

--- a/encoding.bs
+++ b/encoding.bs
@@ -1539,9 +1539,8 @@ must run these steps:
  with that exception.
 
  <p class=note>{{DOMString}} is used here so that a surrogate pair that is split between chunks can
- be correctly reassembled into the appropriate code point in the output. The behaviour is otherwise
- identical to {{USVString}}. In particular, lone surrogates will be replaced with U+FFFD so that the
- output is always well-formed UTF-8.
+ be reassembled into the appropriate scalar value. The behavior is otherwise
+ identical to {{USVString}}. In particular, lone surrogates will be replaced with U+FFFD.
 
  <li><p>Convert <var>input</var> to a <a for=/>stream</a>.
 

--- a/encoding.bs
+++ b/encoding.bs
@@ -1538,6 +1538,11 @@ must run these steps:
  <var>chunk</var> to a {{DOMString}}. If this throws an exception, then return a promise rejected
  with that exception.
 
+ <p class=note>{{DOMString}} is used here so that a surrogate pair that is split between chunks can
+ be correctly reassembled into the appropriate code point in the output. The behaviour is otherwise
+ identical to {{USVString}}. In particular, replacement characters will be used where necessary to
+ make the output valid UTF-8.
+
  <li><p>Convert <var>input</var> to a <a for=/>stream</a>.
 
  <li><p>Let <var>output</var> be a new <a for=/>stream</a>.

--- a/encoding.bs
+++ b/encoding.bs
@@ -1224,16 +1224,16 @@ constructor, when invoked, must run these steps:
  <li><p>Set <var>decForTransform</var>'s <a for=TextDecoder>ignore BOM flag</a> to <var>dec</var>'s
  <a for=TextDecoder>ignore BOM flag</a>.
 
- <li><p>Set <var>decForTransform</var>'s <a for=TextDecoder>decoder</a> to a new <a
- for=/>decoder</a> for <var>decForTransform</var>'s <a for=TextDecoder>encoding</a>, and set
+ <li><p>Set <var>decForTransform</var>'s <a for=TextDecoder>decoder</a> to a new
+ <a for=/>decoder</a> for <var>decForTransform</var>'s <a for=TextDecoder>encoding</a>, and set
  <var>decForTransform</var>'s <a for=TextDecoder>stream</a> to a new <a for=/>stream</a>.
 
  <p class=note>For simplicity, <var>dec</var> and <var>decForTransform</var> have redundant
  members. However, the <a for=TextDecoder>BOM seen flag</a>, <a for=TextDecoder>do not flush
- flag</a>, and <a for=TextDecoder>transform</a> are unused in <var>decForTransform</var>, and <a
- for=TextDecoder>encoding</a>, <a for=TextDecoder>ignore BOM flag</a> and <a for=TextDecoder>error
- mode</a> are identical to <var>dec</var>. It is not necessary for implementations to duplicate
- these member fields.</p>
+ flag</a>, and <a for=TextDecoder>transform</a> are unused in <var>decForTransform</var>, and
+ <a for=TextDecoder>encoding</a>, <a for=TextDecoder>ignore BOM flag</a> and
+ <a for=TextDecoder>error mode</a> are identical to <var>dec</var>. It is not necessary for
+ implementations to duplicate these member fields.</p>
 
  <li><p>Let <var>startAlgorithm</var> be an algorithm that takes no arguments and returns nothing.
 
@@ -1362,9 +1362,9 @@ method, when invoked, must run these steps:
     </ol>
 
    <li><p>Let <var>result</var> be the result of <a>processing</a> <var>token</var> for
-   <var>decForTransform</var>'s <a for=TextDecoder>decoder</a>, <var>decForTransform</var>'s <a
-   for=TextDecoder>stream</a>, <var>output</var>, and <var>decForTransform</var>'s <a
-   for=TextDecoder>error mode</a>.
+   <var>decForTransform</var>'s <a for=TextDecoder>decoder</a>, <var>decForTransform</var>'s
+   <a for=TextDecoder>stream</a>, <var>output</var>, and <var>decForTransform</var>'s
+   <a for=TextDecoder>error mode</a>.
 
    <li><p>If <var>result</var> is <a>error</a>, then return a new promise rejected with a
    {{TypeError}} exception.
@@ -1379,9 +1379,9 @@ these steps:
  <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
 
  <li><p>Let <var>result</var> be the result of <a>processing</a> <a>end-of-stream</a> for
- <var>decForTransform</var>'s <a for=TextDecoder>decoder</a> and <var>decForTransform</var>'s <a
- for=TextDecoder>stream</a>, <var>output</var>, and <var>decForTransform</var>'s <a
- for=TextDecoder>error mode</a>.
+ <var>decForTransform</var>'s <a for=TextDecoder>decoder</a> and <var>decForTransform</var>'s
+ <a for=TextDecoder>stream</a>, <var>output</var>, and <var>decForTransform</var>'s
+ <a for=TextDecoder>error mode</a>.
 
  <li><p>If <var>result</var> is <a>finished</a>, then run these steps:
  <ol>
@@ -1460,13 +1460,24 @@ constructor, when invoked, must run these steps:
 
  <li><p>Set <var>enc</var>'s <a for=TextEncoder>encoder</a> to <a>UTF-8</a>'s <a for=/>encoder</a>.
 
+ <li><p>Let <var>encForTransform</var> be a new {{TextEncoder}} object.
+
+ <li><p>Set <var>encForTransform</var>'s <a for=TextEncoder>encoder</a> to <a>UTF-8</a>'s
+ <a for=/>encoder</a>.
+
+ <p class=note>For simplicity, <var>enc</var> and <var>encForTransform</var> have the same
+ members. However, <a for=TextEncoder>transform</a> is not used by <var>encForTransform</var>
+ and <a for=TextEncoder>pending high surrogate</a> is not used by <var>enc</var>. It is not
+ necessary for implementations to store these unused member fields.</p>
+
  <li><p>Let <var>startAlgorithm</var> be an algorithm that takes no arguments and returns nothing.
 
  <li><p>Let <var>transformAlgorithm</var> be an algorithm which takes a <var>chunk</var> argument
- and runs the <a>encode and enqueue a chunk</a> algorithm with <var>enc</var> and <var>chunk</var>.
+ and runs the <a>encode and enqueue a chunk</a> algorithm with <var>encForTransform</var> and
+ <var>chunk</var>.
 
  <li><p>Let <var>flushAlgorithm</var> be an algorithm which runs the <a>encode and flush</a>
- algorithm with <var>enc</var>.
+ algorithm with <var>encForTransform</var>.
 
  <li><p>Let <var>transform</var> be the result of calling
  <a abstract-op>CreateTransformStream</a>(<var>startAlgorithm</var>, <var>transformAlgorithm</var>,
@@ -1490,19 +1501,6 @@ constructor, when invoked, must run these steps:
 must run these steps:
 
 <ol>
- <li><p>Let <var>readable</var> be <a for=TextEncoder>transform</a>.\[[readable]].
-
- <li><p>If <a abstract-op>IsReadableStreamLocked</a>(<var>readable</var>) is true, then throw a
- {{TypeError}} exception.
-
- <li><p>Let <var>writable</var> be <a for=TextEncoder>transform</a>.\[[writable]].
-
- <li><p>If <a abstract-op>IsWritableStreamLocked</a>(<var>writable</var>) is true, then throw a
- {{TypeError}} exception.
-
- <p class="note">These steps are for consistent behavior with the {{TextDecoder}}
- <a method for=TextDecoder><code>decode(<var>input</var>)</code></a> method.
-
  <li><p>Convert <var>input</var> to a <a for=/>stream</a>.
 
  <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
@@ -1531,7 +1529,7 @@ must run these steps:
 <hr>
 
 <p>The <dfn id=concept-te-encode-and-enqueue>encode and enqueue a chunk</dfn> algorithm, given a
-{{TextEncoder}} <var>enc</var> and <var>chunk</var>, runs these steps:
+{{TextEncoder}} <var>encForTransform</var> and <var>chunk</var>, runs these steps:
 
 <ol>
  <li><p>Let <var>input</var> be the result of <a lt="converted to an IDL value">converting</a>
@@ -1542,9 +1540,7 @@ must run these steps:
 
  <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
 
- <li><p>Let <var>encoder</var> be <a>UTF-8</a>'s <a for=/>encoder</a>.
-
- <li><p>Let <var>controller</var> be <var>enc</var>'s
+ <li><p>Let <var>controller</var> be <var>encForTransform</var>'s
  <a for=TextEncoder>transform</a>.\[[transformStreamController]].
 
  <li>
@@ -1559,33 +1555,38 @@ must run these steps:
     <ol>
      <li><p>Convert <var>output</var> into a byte sequence.
 
+     <li><p>Let <var>chunk</var> be a {{Uint8Array}} object wrapping an {{ArrayBuffer}} containing
+     <var>output</var>.
+
      <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>,
-     <var>output</var>).
+     <var>chunk</var>).
 
      <li><p>Return a new promise resolved with undefined.
     </ol>
 
    <li><p>Let <var>result</var> be the result of executing the <a>convert code unit to scalar
-   value</a> algorithm with <var>enc</var>, <var>token</var> and <var>input</var>.
+   value</a> algorithm with <var>encForTransform</var>, <var>token</var> and <var>input</var>.
 
    <li><p>If <var>result</var> is not <a>continue</a>, then <a>process</a> <var>result</var> for
-   <var>encoder</var>, <var>input</var>, <var>output</var>.
+   <a for=TextEncoder>encoder</a>, <var>input</var>, <var>output</var>.
 
   </ol>
 </ol>
 
 <p>The <dfn id=concept-te-convert-code-unit-to-scalar-value>convert code unit to scalar value</dfn>
-algorithm, given a {{TextEncoder}} <var>enc</var>, <var>token</var> and <var>input</var> stream,
-runs these steps:
+algorithm, given a {{TextEncoder}} <var>encForTransform</var>, <var>token</var> and <var>input</var>
+stream, runs these steps:
 
 <ol>
  <li>
-  <p>If <var>enc</var>'s <a>pending high surrogate</a> is non-null, then run these steps:
+  <p>If <var>encForTransform</var>'s <a>pending high surrogate</a> is non-null, then run these
+  steps:
 
   <ol>
-   <li><p>Let <var>high surrogate</var> be <var>enc</var>'s <a>pending high surrogate</a>.
+   <li><p>Let <var>high surrogate</var> be <var>encForTransform</var>'s <a>pending high
+   surrogate</a>.
 
-   <li><p>Set <var>enc</var>'s <a>pending high surrogate</a> to null.
+   <li><p>Set <var>encForTransform</var>'s <a>pending high surrogate</a> to null.
 
    <li><p>If <var>token</var> is in the range U+DC00 to U+DFFF, inclusive, then return a code point
    whose value is 0x10000 + ((<var>high surrogate</var> &minus; 0xD800) &lt;&lt; 10) +
@@ -1609,33 +1610,31 @@ value string</a>" algorithm from the Infra Standard, but allows for surrogate pa
 between strings.
 
 <p>The <dfn id=concept-te-encode-and-flush>encode and flush</dfn> algorithm, given a
-{{TextEncoder}} <var>enc</var>, runs these steps:
+{{TextEncoder}} <var>encForTransform</var>, runs these steps:
 
 <ol>
  <li>
-  <p>If <var>enc</var>'s <a>pending high surrogate</a> is non-null, then run these steps:
+  <p>If <var>encForTransform</var>'s <a>pending high surrogate</a> is non-null, then run these
+  steps:
 
   <ol>
-   <li><p>Set <var>enc</var>'s <a>pending high surrogate</a> to null.
-
-   <li><p>Let <var>input</var> be a new <a for=/>stream</a>.
-
-   <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
-
-   <li><p>Let <var>encoder</var> be <a>UTF-8</a>'s <a for=/>encoder</a>.
-
-   <li><p>Let <var>controller</var> be <var>enc</var>'s
+   <li><p>Let <var>controller</var> be <var>encForTransform</var>'s
    <a for=TextEncoder>transform</a>.\[[transformStreamController]].
 
    <li><p>Let <var>token</var> be U+FFFD.
 
-   <li><p><a>Process</a> <var>token</var> for <var>encoder</var>, <var>input</var>,
+   <li><p>Let <var>input</var> and <var>output</var> be new <a for=/>stream</a>s.
+
+   <li><p><a>Process</a> <var>token</var> for <a for=TextEncoder>encoder</a>, <var>input</var>,
    <var>output</var>.
 
    <li><p>Convert <var>output</var> into a byte sequence.
 
+   <li><p>Let <var>chunk</var> be a {{Uint8Array}} object wrapping an {{ArrayBuffer}} containing
+   <var>output</var>.
+
    <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>,
-   <var>output</var>).
+   <var>chunk</var>).
   </ol>
 
  <li><p>Return a new promise resolved with undefined.

--- a/encoding.bs
+++ b/encoding.bs
@@ -28,6 +28,24 @@ Translate IDs: dictdef-textdecoderoptions textdecoderoptions,dictdef-textdecodeo
 spec:infra; type:dfn;
     text:code point
     text:ascii case-insensitive
+spec:streams; type:interface;
+    text:ReadableStream
+    text:WritableStream
+</pre>
+
+<pre class=anchors>
+spec: streams; urlPrefix: https://streams.spec.whatwg.org/
+    type:dfn; text:chunk; url:#chunk
+    type:dfn; text:readable stream; url:#readable-stream
+    type:dfn; text:writable stream; url:#writable-stream
+    type:abstract-op; text:CreateTransformStream; url: #create-transform-stream
+    type:abstract-op; text:TransformStreamDefaultControllerEnqueue; url: #transform-stream-default-controller-enqueue
+    type:interface; text:TransformStream; url: #ts-class
+spec: ECMASCRIPT; urlPrefix: https://tc39.github.io/ecma262/
+    text: type; url: #sec-ecmascript-data-types-and-values; type: dfn
+    text: IsDetachedBuffer; url: #sec-isdetachedbuffer; type: abstract-op
+    text: IsSharedArrayBuffer; url: #sec-issharedarraybuffer; type: abstract-op
+    text: internal slot; url: #sec-object-internal-methods-and-internal-slots; type: dfn
 </pre>
 
 
@@ -1066,6 +1084,8 @@ interface TextDecoder {
   readonly attribute DOMString encoding;
   readonly attribute boolean fatal;
   readonly attribute boolean ignoreBOM;
+  readonly attribute ReadableStream readable;
+  readonly attribute WritableStream writable;
   USVString decode(optional BufferSource input, optional TextDecodeOptions options);
 };</pre>
 
@@ -1073,8 +1093,9 @@ interface TextDecoder {
 <dfn for=TextDecoder>decoder</dfn>, <dfn for=TextDecoder>stream</dfn>,
 <dfn for=TextDecoder>ignore BOM flag</dfn> (initially unset),
 <dfn for=TextDecoder>BOM seen flag</dfn> (initially unset),
-<dfn for=TextDecoder>error mode</dfn> (initially "<code>replacement</code>"), and
-<dfn for=TextDecoder>do not flush flag</dfn> (initially unset).
+<dfn for=TextDecoder>error mode</dfn> (initially "<code>replacement</code>"),
+<dfn for=TextDecoder>do not flush flag</dfn> (initially unset), and
+<dfn for=TextDecoder>transform</dfn> (a {{TransformStream}} object).
 
 <p>A {{TextDecoder}} object also has an associated
 <dfn id=concept-td-serialize for=TextDecoder>serialize stream</dfn> algorithm, that given a
@@ -1135,6 +1156,31 @@ control.
  <dt><code><var>decoder</var> . <a attribute for=TextDecoder>ignoreBOM</a></code>
  <dd><p>Returns true if <a for=TextDecoder>ignore BOM flag</a> is set, and false otherwise.
 
+ <dt><code><var>decoder</var> . <a attribute for=TextDecoder>readable</a></code>
+ <dd>
+  <p>Returns a <a>readable stream</a> whose <a>chunks</a> are strings resulting from running <a
+  for=TextDecoder>encoding</a>'s <a for=/>decoder</a> on the chunks written to
+  {{TextDecoder/writable}}.
+
+ <dt><code><var>decoder</var> . <a attribute for=TextDecoder>writable</a></code>
+ <dd>
+  <p>Returns a <a>writable stream</a> which accepts {{BufferSource}} chunks and runs them through <a
+  for=TextDecoder>encoding</a>'s <a for=/>decoder</a> before making them available to
+  {{TextDecoder/readable}}.
+
+  <p>Typically this will be used via the {{ReadableStream/pipeThrough()}} method on a
+  {{ReadableStream}} source.
+
+<pre class=example id=example-textdecode-writable>
+var decoder = new TextDecoder(encoding);
+byteReadable
+  .pipeThrough(decoder)
+  .pipeTo(textWritable);</pre>
+
+  <p>If the <a for=TextDecoder>error mode</a> is "<code>fatal</code>" and
+  <a for=TextDecoder>encoding</a>'s <a for=/>decoder</a> returns <a>error</a>, both {{TextDecoder/readable}}
+  and {{TextDecoder/writable}} will be errored with a {{TypeError}}.
+
  <dt><code><var>decoder</var> . <a method for=TextDecoder lt=decode()>decode([<var>input</var> [, <var>options</var>]])</a></code>
  <dd>
   <p>Returns the result of running <a for=TextDecoder>encoding</a>'s <a for=/>decoder</a>. The
@@ -1174,6 +1220,20 @@ constructor, when invoked, must run these steps:
  <li><p>If <var>options</var>'s <code>ignoreBOM</code> member is true, then set <var>dec</var>'s
  <a for=TextDecoder>ignore BOM flag</a>.
 
+ <li><p>Let <var>startAlgorithm</var> be an algorithm that takes no arguments and returns nothing.
+
+ <li><p>Let <var>transformAlgorithm</var> be an algorithm which takes a <var>chunk</var> argument
+ and runs the <a>decode and enqueue a chunk</a> algorithm with <var>dec</var> and <var>chunk</var>.
+
+ <li><p>Let <var>flushAlgorithm</var> be an algorithm which takes no arguments and runs the <a>flush
+ and enqueue</a> algorithm with <var>dec</var>.
+
+ <li><p>Let <var>transform</var> be the result of calling <a
+ abstract-op>CreateTransformStream</a>(<var>startAlgorithm</var>, <var>transformAlgorithm</var>,
+ <var>flushAlgorithm</var>).
+
+ <li><p>Set <var>dec</var>'s <a for=TextDecoder>transform</a> to <var>transform</var>.
+
  <li><p>Return <var>dec</var>.
 </ol>
 
@@ -1186,10 +1246,31 @@ if <a for=TextDecoder>error mode</a> is "<code>fatal</code>", and false otherwis
 <p>The <dfn attribute for=TextDecoder><code>ignoreBOM</code></dfn> attribute's getter must return
 true if <a for=TextDecoder>ignore BOM flag</a> is set, and false otherwise.
 
+<p>The <dfn attribute for=TextDecoder><code>readable</code></dfn> attribute's getter must return the
+contents of <a for=TextDecoder>transform</a>'s \[[readable]] <a>internal slot</a>.
+
+<p>The <dfn attribute for=TextDecoder><code>writable</code></dfn> attribute's getter must return the
+contents of <a for=TextDecoder>transform</a>'s \[[writable]] <a>internal slot</a>.
+
 <p>The <dfn method for=TextDecoder><code>decode(<var>input</var>, <var>options</var>)</code></dfn>
 method, when invoked, must run these steps:
 
 <ol>
+ <li><p>Let <var>readable</var> be <a for=TextDecoder>transform</a>'s \[[readable]] <a>internal
+ slot</a>.
+
+ <li><p>If <a abstract-op>IsReadableStreamLocked</a>(<var>readable</var>) is true, throw a
+ {{TypeError}} exception.
+
+ <li><p>Let <var>writable</var> be <a for=TextDecoder>transform</a>'s \[[writable]] <a>internal
+ slot</a>.
+
+ <li><p>If <a abstract-op>IsWritableStreamLocked</a>(<var>writable</var>) is true, throw a
+ {{TypeError}} exception.
+
+ <p class="note">These steps ensure that the state of the <a for=/>decoder</a> is not simultaneously modified by
+ the Streams API and this method.
+
  <li><p>If the <a for=TextDecoder>do not flush flag</a> is unset, set <a for=TextDecoder>decoder</a>
  to a new <a for=TextDecoder>encoding</a>'s <a for=/>decoder</a>, set <a for=TextDecoder>stream</a>
  to a new <a for=/>stream</a>, and unset the <a for=TextDecoder>BOM seen flag</a>.
@@ -1241,6 +1322,88 @@ method, when invoked, must run these steps:
   </ol>
 </ol>
 
+<p>The <dfn id=concept-td-decode-and-enqueue>decode and enqueue a chunk</dfn> algorithm, given a
+{{TextDecoder}} <var>dec</var> and a <var>chunk</var>, runs these steps:
+
+<ol>
+ <li><p>If the <a>type</a> of of <var>chunk</var> is not Object, or <var>chunk</var> does not have
+ an \[[ArrayBufferData]] <a>internal slot</a>, or <a
+ abstract-op>IsDetachedBuffer</a>(<var>chunk</var>) is true, or <a
+ abstract-op>IsSharedArrayBuffer</a>(<var>chunk</var>) is true then return <a>a promise rejected
+ with</a> a {{TypeError}}.
+
+ <li><p>If the <a for=TextDecoder>do not flush flag</a> for <var>dec</var> is unset, set
+ <var>dec's</var> <a for=TextDecoder>decoder</a> to a new <a for=/>decoder</a> for <var>dec</var>'s
+ <a for=TextDecoder>encoding</a>, set <var>dec</var>'s <a for=TextDecoder>stream</a> to a new <a
+ for=/>stream</a>, and unset <var>dec</var>'s <a for=TextDecoder>BOM seen flag</a>.
+
+ <li><p>Set <var>dec</var>'s <a for=TextDecoder>do not flush flag</a>.
+
+ <li><p><a>Push</a> a <a lt="get a copy of the buffer source">copy of</a> <var>chunk</var> to
+ <var>dec</var>'s <a for=TextDecoder>stream</a>.
+
+ <li><p>Let <var>controller</var> be <var>dec</var>'s <a for=TextDecoder>transform</a>'s
+ \[[transformStreamController]] <a>internal slot</a>.
+
+ <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
+
+ <li>
+  <p>While true, run these substeps:
+
+  <ol>
+   <li><p>Let <var>token</var> be the result of <a>reading</a> from <var>dec</var>'s <a
+   for=TextDecoder>stream</a>.
+
+   <li>
+    <p>If <var>token</var> is <a>end-of-stream</a>, run these substeps:
+    <ol>
+     <li><p>Let <var>outputChunk</var> be <var>output</var>, <a lt="serialize stream">serialized</a>.
+
+     <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>, <var>outputChunk</var>).
+
+     <li><p>Return <a>a promise resolved with</a> undefined.
+    </ol>
+
+   <li><p>Let <var>result</var> be the result of <a>processing</a> <var>token</var> for
+   <var>dec</var>'s <a for=TextDecoder>decoder</a>, <var>dec</var>'s <a for=TextDecoder>stream</a>,
+   <var>output</var>, and <var>dec's</var> <a for=TextDecoder>error mode</a>.
+
+   <li><p>If <var>result</var> is <a>error</a>, return <a>a promise rejected with</a> a
+   {{TypeError}} exception.
+  </ol>
+</ol>
+
+<p>The <dfn id=concept-td-flush-and-enqueue>flush and enqueue</dfn> algorithm, which handles the end
+of data from the input {{ReadableStream}}, given a {{TextDecoder}} <var>dec</var>, runs these steps:
+
+<ol>
+ <li><p>If the <a for=TextDecoder>do not flush flag</a> for <var>dec</var> is unset, set
+ <var>dec's</var> <a for=TextDecoder>decoder</a> to a new <a for=/>decoder</a> for <var>dec</var>'s
+ <a for=TextDecoder>encoding</a>, set <var>dec</var>'s <a for=TextDecoder>stream</a> to a new <a
+ for=/>stream</a>, and unset <var>dec</var>'s <a for=TextDecoder>BOM seen flag</a>.
+
+ <li><p>Unset <var>dec</var>'s <a for=TextDecoder>do not flush flag</a>.
+
+ <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
+
+ <li><p>Let <var>result</var> be the result of <a>processing</a> <a>end-of-stream</a> for
+ <var>dec</var>'s <a for=TextDecoder>decoder</a> and <var>dec</var>'s <a for=TextDecoder>stream</a>,
+ <var>output</var>, and <var>dec</var>'s <a for=TextDecoder>error mode</a>.
+
+ <li><p>If <var>result</var> is <a>finished</a>, run these substeps:
+ <ol>
+  <li><p>Let <var>outputChunk</var> be <var>output</var>, <a lt="serialize stream">serialized</a>.
+
+  <li><p>Let <var>controller</var> be <var>dec</var>'s <a for=TextDecoder>transform</a>'s
+  \[[transformStreamController]] <a>internal slot</a>.
+
+  <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>, <var>outputChunk</var>).
+
+  <li><p>Return <a>a promise resolved with</a> undefined.
+ </ol>
+
+ <li><p>Otherwise, return <a>a promise rejected with</a> a {{TypeError}}.
+</ol>
 
 <h3 id=interface-textencoder>Interface {{TextEncoder}}</h3>
 
@@ -1249,10 +1412,13 @@ method, when invoked, must run these steps:
  Exposed=(Window,Worker)]
 interface TextEncoder {
   readonly attribute DOMString encoding;
+  readonly attribute ReadableStream readable;
+  readonly attribute WritableStream writable;
   [NewObject] Uint8Array encode(optional USVString input = "");
 };</pre>
 
-<p>A {{TextEncoder}} object has an associated <dfn for=TextEncoder>encoder</dfn>.
+<p>A {{TextEncoder}} object has an associated <dfn for=TextEncoder>encoder</dfn> and <dfn
+for=TextEncoder>transform</dfn> (a {{TransformStream}} object).
 
 <p class="note no-backref">A {{TextEncoder}} object offers no <var>label</var> argument as it only
 supports <a>UTF-8</a>. It also offers no <code>stream</code> option as no <a for=/>encoder</a>
@@ -1267,6 +1433,23 @@ requires buffering of scalar values.
  <dt><code><var>encoder</var> . <a attribute for=TextEncoder>encoding</a></code>
  <dd><p>Returns "<code>utf-8</code>".
 
+ <dt><code><var>encoder</var> . <a attribute for=TextEncoder>readable</a></code>
+ <dd>
+  <p>Returns a <a>readable stream</a> whose <a>chunks</a> are {{Uint8Array}}s resulting from running
+  <a>UTF-8</a>'s <a for=/>encoder</a> on the chunks written to {{TextEncoder/writable}}.
+
+ <dt><code><var>encoder</var> . <a attribute for=TextEncoder>writable</a></code>
+ <dd>
+  <p>Returns a <a>writable stream</a> which accepts string chunks and runs them through
+  <a>UTF-8</a>'s <a for=/>encoder</a> before making them available to {{TextEncoder/readable}}.
+
+  <p>Typically this will be used via the {{ReadableStream/pipeThrough()}} method on a {{ReadableStream}} source.
+
+<pre class=example id=example-textencode-writable>
+textReadable
+  .pipeThrough(new TextEncoder())
+  .pipeTo(byteWritable);</pre>
+
  <dt><code><var>encoder</var> . <a method for=TextEncoder lt=encode()>encode([<var>input</var> = ""])</a></code>
  <dd><p>Returns the result of running <a>UTF-8</a>'s <a for=/>encoder</a>.
 </dl>
@@ -1279,16 +1462,51 @@ constructor, when invoked, must run these steps:
 
  <li><p>Set <var>enc</var>'s <a for=TextEncoder>encoder</a> to <a>UTF-8</a>'s <a for=/>encoder</a>.
 
+ <li><p>Let <var>startAlgorithm</var> be an algorithm that takes no arguments and returns nothing.
+
+ <li><p>Let <var>transformAlgorithm</var> be an algorithm which takes a <var>chunk</var> argument
+ and runs the <a>encode and enqueue a chunk</a> algorithm with <var>enc</var> and <var>chunk</var>.
+
+ <li><p>Let <var>flushAlgorithm</var> be an algorithm which returns <a>a promise resolved with</a>
+ undefined.
+
+ <li><p>Let <var>transform</var> be the result of calling <a
+ abstract-op>CreateTransformStream</a>(<var>startAlgorithm</var>, <var>transformAlgorithm</var>,
+ <var>flushAlgorithm</var>).
+
+ <li><p>Set <var>enc</var>'s <a for=TextEncoder>transform</a> to <var>transform</var>
+
  <li><p>Return <var>enc</var>.
 </ol>
 
 <p>The <dfn attribute for=TextEncoder><code>encoding</code></dfn> attribute's getter must return
 "<code>utf-8</code>".
 
+<p>The <dfn attribute for=TextEncoder><code>readable</code></dfn> attribute's getter must return the
+contents of <a for=TextEncoder>transform</a>'s \[[readable]] <a>internal slot</a>.
+
+<p>The <dfn attribute for=TextEncoder><code>writable</code></dfn> attribute's getter must return the
+contents of <a for=TextEncoder>transform</a>'s \[[writable]] <a>internal slot</a>.
+
 <p>The <dfn method for=TextEncoder><code>encode(<var>input</var>)</code></dfn> method, when invoked,
 must run these steps:
 
 <ol>
+ <li><p>Let <var>readable</var> be <a for=TextEncoder>transform</a>'s \[[readable]] <a>internal
+ slot</a>.
+
+ <li><p>If <a abstract-op>IsReadableStreamLocked</a>(<var>readable</var>) is true, throw a
+ {{TypeError}} exception.
+
+ <li><p>Let <var>writable</var> be <a for=TextEncoder>transform</a>'s \[[writable]] <a>internal
+ slot</a>.
+
+ <li><p>If <a abstract-op>IsWritableStreamLocked</a>(<var>writable</var>) is true, throw a
+ {{TypeError}} exception.
+
+ <p class="note">These steps are for consistent behaviour with the {{TextDecoder}} <a method
+ for=TextDecoder><code>decode(<var>input</var>)</code></a> method.
+
  <li><p>Convert <var>input</var> to a <a for=/>stream</a>.
 
  <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
@@ -1312,6 +1530,48 @@ must run these steps:
 
     <p class=note><a>UTF-8</a> cannot return <a>error</a>.
   </ol>
+</ol>
+
+<p>The <dfn id=concept-td-encode-and-enqueue>encode and enqueue a chunk</dfn> algorithm, given a
+{{TextEncoder}} <var>dec</var> and <var>chunk</var>, runs these steps:
+
+<ol>
+ <li><p>Let <var>input</var> be the result of <a lt="converted to an IDL value">converting</a>
+ <var>chunk</var> to a {{USVString}}. If this throws an exception, return a promise rejected with
+ that exception.
+
+ <li><p>Convert <var>input</var> to a <a for=/>stream</a>.
+
+ <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
+
+ <li><p>Let <var>encoder</var> be <a>UTF-8</a>'s <a for=/>encoder</a>.
+
+ <li><p>Let <var>controller</var> be <var>dec</var>'s <a for=TextEncoder>transform</a>'s
+ \[[transformStreamController]] <a>internal slot</a>.
+
+ <li><p>While true, run these substeps:
+
+ <!--
+      TODO(ricea): This algorithm cannot deal with having a surrogate pair split between two
+      chunks. This is consistent with the encode() method but arguably is a worse limitation in the
+      streaming case.
+ -->
+
+ <ol>
+  <li><p>Let <var>token</var> be the result of <a>reading</a> from <var>input</var>.
+
+  <li><p>Let <var>result</var> be the result of <a>processing</a> <var>token</var> for
+  <var>encoder</var>, <var>input</var>, <var>output</var>.
+
+  <li><p>If <var>result</var> is <a>finished</a>, run these substeps:
+  <ol>
+   <li><p>Convert <var>output</var> into a byte sequence.
+
+   <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>, <var>output</var>).
+
+   <li><p>Return <a>a promise resolved with</a> undefined.
+  </ol>
+ </ol>
 </ol>
 
 

--- a/encoding.bs
+++ b/encoding.bs
@@ -28,24 +28,18 @@ Translate IDs: dictdef-textdecoderoptions textdecoderoptions,dictdef-textdecodeo
 spec:infra; type:dfn;
     text:code point
     text:ascii case-insensitive
-spec:streams; type:interface;
-    text:ReadableStream
-    text:WritableStream
+spec:streams;
+    type:interface; text:ReadableStream
+    type:dfn; text:chunk
+    type:dfn; text:readable stream
+    type:dfn; text:writable stream
 </pre>
 
 <pre class=anchors>
-spec: streams; urlPrefix: https://streams.spec.whatwg.org/
-    type:dfn; text:chunk; url:#chunk
-    type:dfn; text:readable stream; url:#readable-stream
-    type:dfn; text:writable stream; url:#writable-stream
-    type:abstract-op; text:CreateTransformStream; url: #create-transform-stream
-    type:abstract-op; text:TransformStreamDefaultControllerEnqueue; url: #transform-stream-default-controller-enqueue
-    type:interface; text:TransformStream; url: #ts-class
 spec: ECMASCRIPT; urlPrefix: https://tc39.github.io/ecma262/
-    text: type; url: #sec-ecmascript-data-types-and-values; type: dfn
+    text: Type; url: #sec-ecmascript-data-types-and-values; type: dfn
     text: IsDetachedBuffer; url: #sec-isdetachedbuffer; type: abstract-op
     text: IsSharedArrayBuffer; url: #sec-issharedarraybuffer; type: abstract-op
-    text: internal slot; url: #sec-object-internal-methods-and-internal-slots; type: dfn
 </pre>
 
 
@@ -1171,11 +1165,11 @@ control.
   <p>Typically this will be used via the {{ReadableStream/pipeThrough()}} method on a
   {{ReadableStream}} source.
 
-<pre class=example id=example-textdecode-writable>
+  <pre class=example id=example-textdecode-writable><code class=lang-javascript>
 var decoder = new TextDecoder(encoding);
 byteReadable
   .pipeThrough(decoder)
-  .pipeTo(textWritable);</pre>
+  .pipeTo(textWritable);</code></pre>
 
   <p>If the <a for=TextDecoder>error mode</a> is "<code>fatal</code>" and
   <a for=TextDecoder>encoding</a>'s <a for=/>decoder</a> returns <a>error</a>, both {{TextDecoder/readable}}
@@ -1246,26 +1240,24 @@ if <a for=TextDecoder>error mode</a> is "<code>fatal</code>", and false otherwis
 <p>The <dfn attribute for=TextDecoder><code>ignoreBOM</code></dfn> attribute's getter must return
 true if <a for=TextDecoder>ignore BOM flag</a> is set, and false otherwise.
 
-<p>The <dfn attribute for=TextDecoder><code>readable</code></dfn> attribute's getter must return the
-contents of <a for=TextDecoder>transform</a>'s \[[readable]] <a>internal slot</a>.
+<p>The <dfn attribute for=TextDecoder><code>readable</code></dfn> attribute's getter must return <a
+for=TextDecoder>transform</a>.\[[readable]].
 
-<p>The <dfn attribute for=TextDecoder><code>writable</code></dfn> attribute's getter must return the
-contents of <a for=TextDecoder>transform</a>'s \[[writable]] <a>internal slot</a>.
+<p>The <dfn attribute for=TextDecoder><code>writable</code></dfn> attribute's getter must return <a
+for=TextDecoder>transform</a>.\[[writable]].
 
 <p>The <dfn method for=TextDecoder><code>decode(<var>input</var>, <var>options</var>)</code></dfn>
 method, when invoked, must run these steps:
 
 <ol>
- <li><p>Let <var>readable</var> be <a for=TextDecoder>transform</a>'s \[[readable]] <a>internal
- slot</a>.
+ <li><p>Let <var>readable</var> be <a for=TextDecoder>transform</a>.\[[readable]].
 
- <li><p>If <a abstract-op>IsReadableStreamLocked</a>(<var>readable</var>) is true, throw a
+ <li><p>If <a abstract-op>IsReadableStreamLocked</a>(<var>readable</var>) is true, then throw a
  {{TypeError}} exception.
 
- <li><p>Let <var>writable</var> be <a for=TextDecoder>transform</a>'s \[[writable]] <a>internal
- slot</a>.
+ <li><p>Let <var>writable</var> be <a for=TextDecoder>transform</a>.\[[writable]].
 
- <li><p>If <a abstract-op>IsWritableStreamLocked</a>(<var>writable</var>) is true, throw a
+ <li><p>If <a abstract-op>IsWritableStreamLocked</a>(<var>writable</var>) is true, then throw a
  {{TypeError}} exception.
 
  <p class="note">These steps ensure that the state of the <a for=/>decoder</a> is not simultaneously modified by
@@ -1275,7 +1267,7 @@ method, when invoked, must run these steps:
  to a new <a for=TextDecoder>encoding</a>'s <a for=/>decoder</a>, set <a for=TextDecoder>stream</a>
  to a new <a for=/>stream</a>, and unset the <a for=TextDecoder>BOM seen flag</a>.
 
- <li><p>If <var>options</var>'s <code>stream</code> is true, set the
+ <li><p>If <var>options</var>'s <code>stream</code> is true, then set the
  <a for=TextDecoder>do not flush flag</a>, and unset the <a for=TextDecoder>do not flush flag</a>
  otherwise.
 
@@ -1326,11 +1318,10 @@ method, when invoked, must run these steps:
 {{TextDecoder}} <var>dec</var> and a <var>chunk</var>, runs these steps:
 
 <ol>
- <li><p>If the <a>type</a> of of <var>chunk</var> is not Object, or <var>chunk</var> does not have
- an \[[ArrayBufferData]] <a>internal slot</a>, or <a
- abstract-op>IsDetachedBuffer</a>(<var>chunk</var>) is true, or <a
- abstract-op>IsSharedArrayBuffer</a>(<var>chunk</var>) is true then return <a>a promise rejected
- with</a> a {{TypeError}}.
+ <li><p>If <a>Type</a>(<var>chunk</var>) is not Object, or <var>chunk</var> does not have an
+ \[[ArrayBufferData]] internal slot, or <a abstract-op>IsDetachedBuffer</a>(<var>chunk</var>) is
+ true, or <a abstract-op>IsSharedArrayBuffer</a>(<var>chunk</var>) is true, then return a new
+ promise rejected with a {{TypeError}} exception.
 
  <li><p>If the <a for=TextDecoder>do not flush flag</a> for <var>dec</var> is unset, set
  <var>dec's</var> <a for=TextDecoder>decoder</a> to a new <a for=/>decoder</a> for <var>dec</var>'s
@@ -1342,33 +1333,33 @@ method, when invoked, must run these steps:
  <li><p><a>Push</a> a <a lt="get a copy of the buffer source">copy of</a> <var>chunk</var> to
  <var>dec</var>'s <a for=TextDecoder>stream</a>.
 
- <li><p>Let <var>controller</var> be <var>dec</var>'s <a for=TextDecoder>transform</a>'s
- \[[transformStreamController]] <a>internal slot</a>.
+ <li><p>Let <var>controller</var> be <var>dec</var>'s
+ <a for=TextDecoder>transform</a>.\[[transformStreamController]].
 
  <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
 
  <li>
-  <p>While true, run these substeps:
+  <p>While true, run these steps:
 
   <ol>
    <li><p>Let <var>token</var> be the result of <a>reading</a> from <var>dec</var>'s <a
    for=TextDecoder>stream</a>.
 
    <li>
-    <p>If <var>token</var> is <a>end-of-stream</a>, run these substeps:
+    <p>If <var>token</var> is <a>end-of-stream</a>, run these steps:
     <ol>
      <li><p>Let <var>outputChunk</var> be <var>output</var>, <a lt="serialize stream">serialized</a>.
 
      <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>, <var>outputChunk</var>).
 
-     <li><p>Return <a>a promise resolved with</a> undefined.
+     <li><p>Return a new promise resolved with undefined.
     </ol>
 
    <li><p>Let <var>result</var> be the result of <a>processing</a> <var>token</var> for
    <var>dec</var>'s <a for=TextDecoder>decoder</a>, <var>dec</var>'s <a for=TextDecoder>stream</a>,
    <var>output</var>, and <var>dec's</var> <a for=TextDecoder>error mode</a>.
 
-   <li><p>If <var>result</var> is <a>error</a>, return <a>a promise rejected with</a> a
+   <li><p>If <var>result</var> is <a>error</a>, return a new promise rejected with a
    {{TypeError}} exception.
   </ol>
 </ol>
@@ -1390,20 +1381,21 @@ of data from the input {{ReadableStream}}, given a {{TextDecoder}} <var>dec</var
  <var>dec</var>'s <a for=TextDecoder>decoder</a> and <var>dec</var>'s <a for=TextDecoder>stream</a>,
  <var>output</var>, and <var>dec</var>'s <a for=TextDecoder>error mode</a>.
 
- <li><p>If <var>result</var> is <a>finished</a>, run these substeps:
+ <li><p>If <var>result</var> is <a>finished</a>, run these steps:
  <ol>
   <li><p>Let <var>outputChunk</var> be <var>output</var>, <a lt="serialize stream">serialized</a>.
 
-  <li><p>Let <var>controller</var> be <var>dec</var>'s <a for=TextDecoder>transform</a>'s
-  \[[transformStreamController]] <a>internal slot</a>.
+  <li><p>Let <var>controller</var> be <var>dec</var>'s
+  <a for=TextDecoder>transform</a>.\[[transformStreamController]].
 
   <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>, <var>outputChunk</var>).
 
-  <li><p>Return <a>a promise resolved with</a> undefined.
+  <li><p>Return a new promise resolved with undefined.
  </ol>
 
- <li><p>Otherwise, return <a>a promise rejected with</a> a {{TypeError}}.
+ <li><p>Otherwise, return a new promise rejected with a {{TypeError}} exception.
 </ol>
+
 
 <h3 id=interface-textencoder>Interface {{TextEncoder}}</h3>
 
@@ -1446,10 +1438,11 @@ requires buffering of scalar values.
 
   <p>Typically this will be used via the {{ReadableStream/pipeThrough()}} method on a {{ReadableStream}} source.
 
-<pre class=example id=example-textencode-writable>
+
+  <pre class=example id=example-textencode-writable><code class=lang-javascript>
 textReadable
   .pipeThrough(new TextEncoder())
-  .pipeTo(byteWritable);</pre>
+  .pipeTo(byteWritable);</code></pre>
 
  <dt><code><var>encoder</var> . <a method for=TextEncoder lt=encode()>encode([<var>input</var> = ""])</a></code>
  <dd><p>Returns the result of running <a>UTF-8</a>'s <a for=/>encoder</a>.
@@ -1483,26 +1476,24 @@ constructor, when invoked, must run these steps:
 <p>The <dfn attribute for=TextEncoder><code>encoding</code></dfn> attribute's getter must return
 "<code>utf-8</code>".
 
-<p>The <dfn attribute for=TextEncoder><code>readable</code></dfn> attribute's getter must return the
-contents of <a for=TextEncoder>transform</a>'s \[[readable]] <a>internal slot</a>.
+<p>The <dfn attribute for=TextEncoder><code>readable</code></dfn> attribute's getter must return <a
+for=TextEncoder>transform</a>.\[[readable]].
 
-<p>The <dfn attribute for=TextEncoder><code>writable</code></dfn> attribute's getter must return the
-contents of <a for=TextEncoder>transform</a>'s \[[writable]] <a>internal slot</a>.
+<p>The <dfn attribute for=TextEncoder><code>writable</code></dfn> attribute's getter must return <a
+for=TextEncoder>transform</a>.\[[writable]].
 
 <p>The <dfn method for=TextEncoder><code>encode(<var>input</var>)</code></dfn> method, when invoked,
 must run these steps:
 
 <ol>
- <li><p>Let <var>readable</var> be <a for=TextEncoder>transform</a>'s \[[readable]] <a>internal
- slot</a>.
+ <li><p>Let <var>readable</var> be <a for=TextEncoder>transform</a>.\[[readable]].
 
- <li><p>If <a abstract-op>IsReadableStreamLocked</a>(<var>readable</var>) is true, throw a
+ <li><p>If <a abstract-op>IsReadableStreamLocked</a>(<var>readable</var>) is true, then throw a
  {{TypeError}} exception.
 
- <li><p>Let <var>writable</var> be <a for=TextEncoder>transform</a>'s \[[writable]] <a>internal
- slot</a>.
+ <li><p>Let <var>writable</var> be <a for=TextEncoder>transform</a>.\[[writable]].
 
- <li><p>If <a abstract-op>IsWritableStreamLocked</a>(<var>writable</var>) is true, throw a
+ <li><p>If <a abstract-op>IsWritableStreamLocked</a>(<var>writable</var>) is true, then throw a
  {{TypeError}} exception.
 
  <p class="note">These steps are for consistent behaviour with the {{TextDecoder}} <a method
@@ -1547,15 +1538,15 @@ must run these steps:
 
  <li><p>Let <var>encoder</var> be <a>UTF-8</a>'s <a for=/>encoder</a>.
 
- <li><p>Let <var>controller</var> be <var>enc</var>'s <a for=TextEncoder>transform</a>'s
- \[[transformStreamController]] <a>internal slot</a>.
+ <li><p>Let <var>controller</var> be <var>enc</var>'s <a
+ for=TextEncoder>transform</a>.\[[transformStreamController]].
 
- <li><p>While true, run these substeps:
+ <li><p>While true, run these steps:
 
  <ol>
   <li><p>Let <var>token</var> be the result of <a>reading</a> from <var>input</var>.
 
-  <li><p>If <var>token</var> is <a>end-of-stream</a> then run these substeps:
+  <li><p>If <var>token</var> is <a>end-of-stream</a>, then run these steps:
 
   <ol>
    <li><p>Convert <var>output</var> into a byte sequence.
@@ -1563,11 +1554,11 @@ must run these steps:
    <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>,
    <var>output</var>).
 
-   <li><p>Return <a>a promise resolved with</a> undefined.
+   <li><p>Return a new promise resolved with undefined.
   </ol>
 
-  <li><p>Let <var>result</var> by the result of executing the <a>convert code unit to scalar value</a>
-  algorithm with <var>enc</var> and <var>token</var>.
+  <li><p>Let <var>result</var> be the result of executing the <a>convert code unit to scalar
+  value</a> algorithm with <var>enc</var>, <var>token</var> and <var>input</var>.
 
   <li><p>If <var>result</var> is not <a>continue</a>, <a>process</a> <var>result</var> for
   <var>encoder</var>, <var>input</var>, <var>output</var>.
@@ -1577,10 +1568,11 @@ must run these steps:
 
 
 <p>The <dfn id=concept-te-convert-code-unit-to-scalar-value>convert code unit to scalar value</dfn>
-algorithm, given a {{TextEncoder}} <var>enc</var> and <var>token</var>, runs these steps:
+algorithm, given a {{TextEncoder}} <var>enc</var>, <var>token</var> and <var>input</var> stream,
+runs these steps:
 
 <ol>
- <li><p>If <var>enc</var>'s <a>pending high surrogate</a> is set, run these substeps:
+ <li><p>If <var>enc</var>'s <a>pending high surrogate</a> is set, run these steps:
 
  <ol>
   <li><p>Let <var>high surrogate</var> be <var>enc</var>'s <a>pending high surrogate</a>.
@@ -1590,6 +1582,8 @@ algorithm, given a {{TextEncoder}} <var>enc</var> and <var>token</var>, runs the
   <li><p>If <var>token</var> is in the range U+DC00 to U+DFFF, inclusive, return a code point whose
   value is 0x10000 + ((<var>high surrogate</var> &minus; 0xD800) &lt;&lt; 10) + (<var>token</var>
   &minus; 0xDC00).
+
+  <li><p><a>Prepend</a> <var>token</var> to <var>input</var>.
 
   <li><p>Return U+FFFD.
  </ol>
@@ -1611,7 +1605,7 @@ strings.
 {{TextEncoder}} <var>enc</var>, runs these steps:
 
 <ol>
- <li><p>If <var>enc</var>'s <a>pending high surrogate</a> is set, run these substeps:
+ <li><p>If <var>enc</var>'s <a>pending high surrogate</a> is set, run these steps:
 
  <ol>
   <li><p>Unset <var>enc</var>'s <a>pending high surrogate</a>
@@ -1622,8 +1616,8 @@ strings.
 
   <li><p>Let <var>encoder</var> be <a>UTF-8</a>'s <a for=/>encoder</a>.
 
-  <li><p>Let <var>controller</var> be <var>enc</var>'s <a for=TextEncoder>transform</a>'s
-  \[[transformStreamController]] <a>internal slot</a>.
+  <li><p>Let <var>controller</var> be <var>enc</var>'s <a
+  for=TextEncoder>transform</a>.\[[transformStreamController]].
 
   <li><p>Let <var>token</var> be U+FFFD.
 
@@ -1635,7 +1629,7 @@ strings.
   <var>output</var>).
  </ol>
 
- <li><p>Return <a>a promise resolved with</a> undefined.
+ <li><p>Return a new promise resolved with undefined.
 </ol>
 
 

--- a/encoding.bs
+++ b/encoding.bs
@@ -1416,7 +1416,7 @@ interface TextEncoder {
 
 <p>A {{TextEncoder}} object has an associated <dfn for=TextEncoder>encoder</dfn>,
 <dfn for=TextEncoder>transform</dfn> and <dfn for=TextEncoder>pending high surrogate</dfn>
-(initially unset).
+(initially null).
 
 <p class="note no-backref">A {{TextEncoder}} object offers no <var>label</var> argument as it only
 supports <a>UTF-8</a>. It also offers no <code>stream</code> option as no <a for=/>encoder</a>
@@ -1582,12 +1582,12 @@ runs these steps:
 
 <ol>
  <li>
-  <p>If <var>enc</var>'s <a>pending high surrogate</a> is set, then run these steps:
+  <p>If <var>enc</var>'s <a>pending high surrogate</a> is non-null, then run these steps:
 
   <ol>
    <li><p>Let <var>high surrogate</var> be <var>enc</var>'s <a>pending high surrogate</a>.
 
-   <li><p>Unset <var>enc</var>'s <a>pending high surrogate</a>.
+   <li><p>Set <var>enc</var>'s <a>pending high surrogate</a> to null.
 
    <li><p>If <var>token</var> is in the range U+DC00 to U+DFFF, inclusive, then return a code point
    whose value is 0x10000 + ((<var>high surrogate</var> &minus; 0xD800) &lt;&lt; 10) +
@@ -1615,10 +1615,10 @@ between strings.
 
 <ol>
  <li>
-  <p>If <var>enc</var>'s <a>pending high surrogate</a> is set, then run these steps:
+  <p>If <var>enc</var>'s <a>pending high surrogate</a> is non-null, then run these steps:
 
   <ol>
-   <li><p>Unset <var>enc</var>'s <a>pending high surrogate</a>
+   <li><p>Set <var>enc</var>'s <a>pending high surrogate</a> to null.
 
    <li><p>Let <var>input</var> be a new <a for=/>stream</a>.
 

--- a/encoding.bs
+++ b/encoding.bs
@@ -1089,7 +1089,7 @@ interface TextDecoder {
 <dfn for=TextDecoder>BOM seen flag</dfn> (initially unset),
 <dfn for=TextDecoder>error mode</dfn> (initially "<code>replacement</code>"),
 <dfn for=TextDecoder>do not flush flag</dfn> (initially unset), and
-<dfn for=TextDecoder>transform</dfn> (a {{TransformStream}} object).
+<dfn for=TextDecoder>transform</dfn>.
 
 <p>A {{TextDecoder}} object also has an associated
 <dfn id=concept-td-serialize for=TextDecoder>serialize stream</dfn> algorithm, that given a
@@ -1415,8 +1415,8 @@ interface TextEncoder {
 };</pre>
 
 <p>A {{TextEncoder}} object has an associated <dfn for=TextEncoder>encoder</dfn>,
-<dfn for=TextEncoder>transform</dfn> (a {{TransformStream}} object) and
-<dfn for=TextEncoder>pending high surrogate</dfn> (initially unset).
+<dfn for=TextEncoder>transform</dfn> and <dfn for=TextEncoder>pending high surrogate</dfn>
+(initially unset).
 
 <p class="note no-backref">A {{TextEncoder}} object offers no <var>label</var> argument as it only
 supports <a>UTF-8</a>. It also offers no <code>stream</code> option as no <a for=/>encoder</a>

--- a/encoding.bs
+++ b/encoding.bs
@@ -1549,29 +1549,31 @@ must run these steps:
  <li><p>Let <var>controller</var> be <var>enc</var>'s
  <a for=TextEncoder>transform</a>.\[[transformStreamController]].
 
- <li><p>While true, run these steps:
-
- <ol>
-  <li><p>Let <var>token</var> be the result of <a>reading</a> from <var>input</var>.
-
-  <li><p>If <var>token</var> is <a>end-of-stream</a>, then run these steps:
+ <li>
+  <p>While true, run these steps:
 
   <ol>
-   <li><p>Convert <var>output</var> into a byte sequence.
+   <li><p>Let <var>token</var> be the result of <a>reading</a> from <var>input</var>.
 
-   <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>,
-   <var>output</var>).
+   <li>
+    <p>If <var>token</var> is <a>end-of-stream</a>, then run these steps:
 
-   <li><p>Return a new promise resolved with undefined.
+    <ol>
+     <li><p>Convert <var>output</var> into a byte sequence.
+
+     <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>,
+     <var>output</var>).
+
+     <li><p>Return a new promise resolved with undefined.
+    </ol>
+
+   <li><p>Let <var>result</var> be the result of executing the <a>convert code unit to scalar
+   value</a> algorithm with <var>enc</var>, <var>token</var> and <var>input</var>.
+
+   <li><p>If <var>result</var> is not <a>continue</a>, then <a>process</a> <var>result</var> for
+   <var>encoder</var>, <var>input</var>, <var>output</var>.
+
   </ol>
-
-  <li><p>Let <var>result</var> be the result of executing the <a>convert code unit to scalar
-  value</a> algorithm with <var>enc</var>, <var>token</var> and <var>input</var>.
-
-  <li><p>If <var>result</var> is not <a>continue</a>, then <a>process</a> <var>result</var> for
-  <var>encoder</var>, <var>input</var>, <var>output</var>.
-
- </ol>
 </ol>
 
 <p>The <dfn id=concept-te-convert-code-unit-to-scalar-value>convert code unit to scalar value</dfn>
@@ -1579,21 +1581,22 @@ algorithm, given a {{TextEncoder}} <var>enc</var>, <var>token</var> and <var>inp
 runs these steps:
 
 <ol>
- <li><p>If <var>enc</var>'s <a>pending high surrogate</a> is set, run these steps:
+ <li>
+  <p>If <var>enc</var>'s <a>pending high surrogate</a> is set, run these steps:
 
- <ol>
-  <li><p>Let <var>high surrogate</var> be <var>enc</var>'s <a>pending high surrogate</a>.
+  <ol>
+   <li><p>Let <var>high surrogate</var> be <var>enc</var>'s <a>pending high surrogate</a>.
 
-  <li><p>Unset <var>enc</var>'s <a>pending high surrogate</a>.
+   <li><p>Unset <var>enc</var>'s <a>pending high surrogate</a>.
 
-  <li><p>If <var>token</var> is in the range U+DC00 to U+DFFF, inclusive, then return a code point
-  whose value is 0x10000 + ((<var>high surrogate</var> &minus; 0xD800) &lt;&lt; 10) +
-  (<var>token</var> &minus; 0xDC00).
+   <li><p>If <var>token</var> is in the range U+DC00 to U+DFFF, inclusive, then return a code point
+   whose value is 0x10000 + ((<var>high surrogate</var> &minus; 0xD800) &lt;&lt; 10) +
+   (<var>token</var> &minus; 0xDC00).
 
-  <li><p><a>Prepend</a> <var>token</var> to <var>input</var>.
+   <li><p><a>Prepend</a> <var>token</var> to <var>input</var>.
 
-  <li><p>Return U+FFFD.
- </ol>
+   <li><p>Return U+FFFD.
+  </ol>
 
  <li><p>If <var>token</var> is in the range U+D800 to U+DBFF, inclusive, then set <a>pending high
  surrogate</a> to <var>token</var> and return <a>continue</a>.
@@ -1611,30 +1614,31 @@ strings.
 {{TextEncoder}} <var>enc</var>, runs these steps:
 
 <ol>
- <li><p>If <var>enc</var>'s <a>pending high surrogate</a> is set, run these steps:
+ <li>
+  <p>If <var>enc</var>'s <a>pending high surrogate</a> is set, run these steps:
 
- <ol>
-  <li><p>Unset <var>enc</var>'s <a>pending high surrogate</a>
+  <ol>
+   <li><p>Unset <var>enc</var>'s <a>pending high surrogate</a>
 
-  <li><p>Let <var>input</var> be a new <a for=/>stream</a>.
+   <li><p>Let <var>input</var> be a new <a for=/>stream</a>.
 
-  <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
+   <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
 
-  <li><p>Let <var>encoder</var> be <a>UTF-8</a>'s <a for=/>encoder</a>.
+   <li><p>Let <var>encoder</var> be <a>UTF-8</a>'s <a for=/>encoder</a>.
 
-  <li><p>Let <var>controller</var> be <var>enc</var>'s
-  <a for=TextEncoder>transform</a>.\[[transformStreamController]].
+   <li><p>Let <var>controller</var> be <var>enc</var>'s
+   <a for=TextEncoder>transform</a>.\[[transformStreamController]].
 
-  <li><p>Let <var>token</var> be U+FFFD.
+   <li><p>Let <var>token</var> be U+FFFD.
 
-  <li><p><a>Process</a> <var>token</var> for <var>encoder</var>, <var>input</var>,
-  <var>output</var>.
+   <li><p><a>Process</a> <var>token</var> for <var>encoder</var>, <var>input</var>,
+   <var>output</var>.
 
-  <li><p>Convert <var>output</var> into a byte sequence.
+   <li><p>Convert <var>output</var> into a byte sequence.
 
-  <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>,
-  <var>output</var>).
- </ol>
+   <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>,
+   <var>output</var>).
+  </ol>
 
  <li><p>Return a new promise resolved with undefined.
 </ol>

--- a/encoding.bs
+++ b/encoding.bs
@@ -1084,8 +1084,8 @@ interface TextDecoder {
   readonly attribute DOMString encoding;
   readonly attribute boolean fatal;
   readonly attribute boolean ignoreBOM;
-  readonly attribute ReadableStream readable;
-  readonly attribute WritableStream writable;
+  [SameObject] readonly attribute ReadableStream readable;
+  [SameObject] readonly attribute WritableStream writable;
   USVString decode(optional BufferSource input, optional TextDecodeOptions options);
 };</pre>
 
@@ -1412,13 +1412,14 @@ of data from the input {{ReadableStream}}, given a {{TextDecoder}} <var>dec</var
  Exposed=(Window,Worker)]
 interface TextEncoder {
   readonly attribute DOMString encoding;
-  readonly attribute ReadableStream readable;
-  readonly attribute WritableStream writable;
+  [SameObject] readonly attribute ReadableStream readable;
+  [SameObject] readonly attribute WritableStream writable;
   [NewObject] Uint8Array encode(optional USVString input = "");
 };</pre>
 
-<p>A {{TextEncoder}} object has an associated <dfn for=TextEncoder>encoder</dfn> and <dfn
-for=TextEncoder>transform</dfn> (a {{TransformStream}} object).
+<p>A {{TextEncoder}} object has an associated <dfn for=TextEncoder>encoder</dfn>, <dfn
+for=TextEncoder>transform</dfn> (a {{TransformStream}} object) and <dfn for=TextEncoder>pending high
+surrogate</dfn> (initially unset).
 
 <p class="note no-backref">A {{TextEncoder}} object offers no <var>label</var> argument as it only
 supports <a>UTF-8</a>. It also offers no <code>stream</code> option as no <a for=/>encoder</a>
@@ -1467,8 +1468,8 @@ constructor, when invoked, must run these steps:
  <li><p>Let <var>transformAlgorithm</var> be an algorithm which takes a <var>chunk</var> argument
  and runs the <a>encode and enqueue a chunk</a> algorithm with <var>enc</var> and <var>chunk</var>.
 
- <li><p>Let <var>flushAlgorithm</var> be an algorithm which returns <a>a promise resolved with</a>
- undefined.
+ <li><p>Let <var>flushAlgorithm</var> be an algorithm which runs the <a>encode and flush</a>
+ algorithm with <var>enc</var>.
 
  <li><p>Let <var>transform</var> be the result of calling <a
  abstract-op>CreateTransformStream</a>(<var>startAlgorithm</var>, <var>transformAlgorithm</var>,
@@ -1532,12 +1533,12 @@ must run these steps:
   </ol>
 </ol>
 
-<p>The <dfn id=concept-td-encode-and-enqueue>encode and enqueue a chunk</dfn> algorithm, given a
-{{TextEncoder}} <var>dec</var> and <var>chunk</var>, runs these steps:
+<p>The <dfn id=concept-te-encode-and-enqueue>encode and enqueue a chunk</dfn> algorithm, given a
+{{TextEncoder}} <var>enc</var> and <var>chunk</var>, runs these steps:
 
 <ol>
  <li><p>Let <var>input</var> be the result of <a lt="converted to an IDL value">converting</a>
- <var>chunk</var> to a {{USVString}}. If this throws an exception, return a promise rejected with
+ <var>chunk</var> to a {{DOMString}}. If this throws an exception, return a promise rejected with
  that exception.
 
  <li><p>Convert <var>input</var> to a <a for=/>stream</a>.
@@ -1546,34 +1547,96 @@ must run these steps:
 
  <li><p>Let <var>encoder</var> be <a>UTF-8</a>'s <a for=/>encoder</a>.
 
- <li><p>Let <var>controller</var> be <var>dec</var>'s <a for=TextEncoder>transform</a>'s
+ <li><p>Let <var>controller</var> be <var>enc</var>'s <a for=TextEncoder>transform</a>'s
  \[[transformStreamController]] <a>internal slot</a>.
 
  <li><p>While true, run these substeps:
 
- <!--
-      TODO(ricea): This algorithm cannot deal with having a surrogate pair split between two
-      chunks. This is consistent with the encode() method but arguably is a worse limitation in the
-      streaming case.
- -->
-
  <ol>
   <li><p>Let <var>token</var> be the result of <a>reading</a> from <var>input</var>.
 
-  <li><p>Let <var>result</var> be the result of <a>processing</a> <var>token</var> for
-  <var>encoder</var>, <var>input</var>, <var>output</var>.
+  <li><p>If <var>token</var> is <a>end-of-stream</a> then run these substeps:
 
-  <li><p>If <var>result</var> is <a>finished</a>, run these substeps:
   <ol>
    <li><p>Convert <var>output</var> into a byte sequence.
 
-   <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>, <var>output</var>).
+   <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>,
+   <var>output</var>).
 
    <li><p>Return <a>a promise resolved with</a> undefined.
   </ol>
+
+  <li><p>Let <var>result</var> by the result of executing the <a>convert code unit to scalar value</a>
+  algorithm with <var>enc</var> and <var>token</var>.
+
+  <li><p>If <var>result</var> is not <a>continue</a>, <a>process</a> <var>result</var> for
+  <var>encoder</var>, <var>input</var>, <var>output</var>.
+
  </ol>
 </ol>
 
+
+<p>The <dfn id=concept-te-convert-code-unit-to-scalar-value>convert code unit to scalar value</dfn>
+algorithm, given a {{TextEncoder}} <var>enc</var> and <var>token</var>, runs these steps:
+
+<ol>
+ <li><p>If <var>enc</var>'s <a>pending high surrogate</a> is set, run these substeps:
+
+ <ol>
+  <li><p>Let <var>high surrogate</var> be <var>enc</var>'s <a>pending high surrogate</a>.
+
+  <li><p>Unset <var>enc</var>'s <a>pending high surrogate</a>.
+
+  <li><p>If <var>token</var> is in the range U+DC00 to U+DFFF, inclusive, return a code point whose
+  value is 0x10000 + ((<var>high surrogate</var> &minus; 0xD800) &lt;&lt; 10) + (<var>token</var>
+  &minus; 0xDC00).
+
+  <li><p>Return U+FFFD.
+ </ol>
+
+ <li><p>If <var>token</var> is in the range U+D800 to U+DBFF, inclusive, set <a>pending high
+ surrogate</a> to <var>token</var> and return <a>continue</a>.
+
+ <li><p>If <var>token</var> is in the range U+DC00 to U+DFFF, inclusive, return U+FFFD.
+
+ <li><p>Return <var>token</var>.
+</ol>
+
+<p class=note>This is equivalent to the <a spec=webidl>convert a DOMString to a sequence of Unicode
+scalar values</a> algorithm from [[WEBIDL]], but allows for surrogate pairs that are split between
+strings.
+
+
+<p>The <dfn id=concept-te-encode-and-flush>encode and flush</dfn> algorithm, given a
+{{TextEncoder}} <var>enc</var>, runs these steps:
+
+<ol>
+ <li><p>If <var>enc</var>'s <a>pending high surrogate</a> is set, run these substeps:
+
+ <ol>
+  <li><p>Unset <var>enc</var>'s <a>pending high surrogate</a>
+
+  <li><p>Let <var>input</var> be a new <a for=/>stream</a>.
+
+  <li><p>Let <var>output</var> be a new <a for=/>stream</a>.
+
+  <li><p>Let <var>encoder</var> be <a>UTF-8</a>'s <a for=/>encoder</a>.
+
+  <li><p>Let <var>controller</var> be <var>enc</var>'s <a for=TextEncoder>transform</a>'s
+  \[[transformStreamController]] <a>internal slot</a>.
+
+  <li><p>Let <var>token</var> be U+FFFD.
+
+  <li><p><a>Process</a> <var>token</var> for <var>encoder</var>, <var>input</var>, <var>output</var>.
+
+  <li><p>Convert <var>output</var> into a byte sequence.
+
+  <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>,
+  <var>output</var>).
+ </ol>
+
+ <li><p>Return <a>a promise resolved with</a> undefined.
+</ol>
 
 
 <h2 id=the-encoding>The encoding</h2>

--- a/encoding.bs
+++ b/encoding.bs
@@ -1348,7 +1348,7 @@ method, when invoked, must run these steps:
    <a for=TextDecoder>stream</a>.
 
    <li>
-    <p>If <var>token</var> is <a>end-of-stream</a>, run these steps:
+    <p>If <var>token</var> is <a>end-of-stream</a>, then run these steps:
     <ol>
      <li><p>Let <var>outputChunk</var> be <var>output</var>,
      <a lt="serialize stream">serialized</a>.
@@ -1385,7 +1385,7 @@ of data from the input {{ReadableStream}}, given a {{TextDecoder}} <var>dec</var
  <var>dec</var>'s <a for=TextDecoder>decoder</a> and <var>dec</var>'s <a for=TextDecoder>stream</a>,
  <var>output</var>, and <var>dec</var>'s <a for=TextDecoder>error mode</a>.
 
- <li><p>If <var>result</var> is <a>finished</a>, run these steps:
+ <li><p>If <var>result</var> is <a>finished</a>, then run these steps:
  <ol>
   <li><p>Let <var>outputChunk</var> be <var>output</var>, <a lt="serialize stream">serialized</a>.
 
@@ -1582,7 +1582,7 @@ runs these steps:
 
 <ol>
  <li>
-  <p>If <var>enc</var>'s <a>pending high surrogate</a> is set, run these steps:
+  <p>If <var>enc</var>'s <a>pending high surrogate</a> is set, then run these steps:
 
   <ol>
    <li><p>Let <var>high surrogate</var> be <var>enc</var>'s <a>pending high surrogate</a>.
@@ -1615,7 +1615,7 @@ strings.
 
 <ol>
  <li>
-  <p>If <var>enc</var>'s <a>pending high surrogate</a> is set, run these steps:
+  <p>If <var>enc</var>'s <a>pending high surrogate</a> is set, then run these steps:
 
   <ol>
    <li><p>Unset <var>enc</var>'s <a>pending high surrogate</a>

--- a/encoding.bs
+++ b/encoding.bs
@@ -1152,14 +1152,14 @@ control.
 
  <dt><code><var>decoder</var> . <a attribute for=TextDecoder>readable</a></code>
  <dd>
-  <p>Returns a <a>readable stream</a> whose <a>chunks</a> are strings resulting from running <a
-  for=TextDecoder>encoding</a>'s <a for=/>decoder</a> on the chunks written to
+  <p>Returns a <a>readable stream</a> whose <a>chunks</a> are strings resulting from running
+  <a for=TextDecoder>encoding</a>'s <a for=/>decoder</a> on the chunks written to
   {{TextDecoder/writable}}.
 
  <dt><code><var>decoder</var> . <a attribute for=TextDecoder>writable</a></code>
  <dd>
-  <p>Returns a <a>writable stream</a> which accepts {{BufferSource}} chunks and runs them through <a
-  for=TextDecoder>encoding</a>'s <a for=/>decoder</a> before making them available to
+  <p>Returns a <a>writable stream</a> which accepts {{BufferSource}} chunks and runs them through
+  <a for=TextDecoder>encoding</a>'s <a for=/>decoder</a> before making them available to
   {{TextDecoder/readable}}.
 
   <p>Typically this will be used via the {{ReadableStream/pipeThrough()}} method on a
@@ -1172,8 +1172,8 @@ byteReadable
   .pipeTo(textWritable);</code></pre>
 
   <p>If the <a for=TextDecoder>error mode</a> is "<code>fatal</code>" and
-  <a for=TextDecoder>encoding</a>'s <a for=/>decoder</a> returns <a>error</a>, both {{TextDecoder/readable}}
-  and {{TextDecoder/writable}} will be errored with a {{TypeError}}.
+  <a for=TextDecoder>encoding</a>'s <a for=/>decoder</a> returns <a>error</a>, both
+  {{TextDecoder/readable}} and {{TextDecoder/writable}} will be errored with a {{TypeError}}.
 
  <dt><code><var>decoder</var> . <a method for=TextDecoder lt=decode()>decode([<var>input</var> [, <var>options</var>]])</a></code>
  <dd>
@@ -1222,8 +1222,8 @@ constructor, when invoked, must run these steps:
  <li><p>Let <var>flushAlgorithm</var> be an algorithm which takes no arguments and runs the <a>flush
  and enqueue</a> algorithm with <var>dec</var>.
 
- <li><p>Let <var>transform</var> be the result of calling <a
- abstract-op>CreateTransformStream</a>(<var>startAlgorithm</var>, <var>transformAlgorithm</var>,
+ <li><p>Let <var>transform</var> be the result of calling
+ <a abstract-op>CreateTransformStream</a>(<var>startAlgorithm</var>, <var>transformAlgorithm</var>,
  <var>flushAlgorithm</var>).
 
  <li><p>Set <var>dec</var>'s <a for=TextDecoder>transform</a> to <var>transform</var>.
@@ -1240,11 +1240,11 @@ if <a for=TextDecoder>error mode</a> is "<code>fatal</code>", and false otherwis
 <p>The <dfn attribute for=TextDecoder><code>ignoreBOM</code></dfn> attribute's getter must return
 true if <a for=TextDecoder>ignore BOM flag</a> is set, and false otherwise.
 
-<p>The <dfn attribute for=TextDecoder><code>readable</code></dfn> attribute's getter must return <a
-for=TextDecoder>transform</a>.\[[readable]].
+<p>The <dfn attribute for=TextDecoder><code>readable</code></dfn> attribute's getter must return
+<a for=TextDecoder>transform</a>.\[[readable]].
 
-<p>The <dfn attribute for=TextDecoder><code>writable</code></dfn> attribute's getter must return <a
-for=TextDecoder>transform</a>.\[[writable]].
+<p>The <dfn attribute for=TextDecoder><code>writable</code></dfn> attribute's getter must return
+<a for=TextDecoder>transform</a>.\[[writable]].
 
 <p>The <dfn method for=TextDecoder><code>decode(<var>input</var>, <var>options</var>)</code></dfn>
 method, when invoked, must run these steps:
@@ -1260,8 +1260,8 @@ method, when invoked, must run these steps:
  <li><p>If <a abstract-op>IsWritableStreamLocked</a>(<var>writable</var>) is true, then throw a
  {{TypeError}} exception.
 
- <p class="note">These steps ensure that the state of the <a for=/>decoder</a> is not simultaneously modified by
- the Streams API and this method.
+ <p class="note">These steps ensure that the state of the <a for=/>decoder</a> is not simultaneously
+ modified by the Streams API and this method.
 
  <li><p>If the <a for=TextDecoder>do not flush flag</a> is unset, set <a for=TextDecoder>decoder</a>
  to a new <a for=TextDecoder>encoding</a>'s <a for=/>decoder</a>, set <a for=TextDecoder>stream</a>
@@ -1325,8 +1325,8 @@ method, when invoked, must run these steps:
 
  <li><p>If the <a for=TextDecoder>do not flush flag</a> for <var>dec</var> is unset, set
  <var>dec's</var> <a for=TextDecoder>decoder</a> to a new <a for=/>decoder</a> for <var>dec</var>'s
- <a for=TextDecoder>encoding</a>, set <var>dec</var>'s <a for=TextDecoder>stream</a> to a new <a
- for=/>stream</a>, and unset <var>dec</var>'s <a for=TextDecoder>BOM seen flag</a>.
+ <a for=TextDecoder>encoding</a>, set <var>dec</var>'s <a for=TextDecoder>stream</a> to a new
+ <a for=/>stream</a>, and unset <var>dec</var>'s <a for=TextDecoder>BOM seen flag</a>.
 
  <li><p>Set <var>dec</var>'s <a for=TextDecoder>do not flush flag</a>.
 
@@ -1342,15 +1342,17 @@ method, when invoked, must run these steps:
   <p>While true, run these steps:
 
   <ol>
-   <li><p>Let <var>token</var> be the result of <a>reading</a> from <var>dec</var>'s <a
-   for=TextDecoder>stream</a>.
+   <li><p>Let <var>token</var> be the result of <a>reading</a> from <var>dec</var>'s
+   <a for=TextDecoder>stream</a>.
 
    <li>
     <p>If <var>token</var> is <a>end-of-stream</a>, run these steps:
     <ol>
-     <li><p>Let <var>outputChunk</var> be <var>output</var>, <a lt="serialize stream">serialized</a>.
+     <li><p>Let <var>outputChunk</var> be <var>output</var>,
+     <a lt="serialize stream">serialized</a>.
 
-     <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>, <var>outputChunk</var>).
+     <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>,
+     <var>outputChunk</var>).
 
      <li><p>Return a new promise resolved with undefined.
     </ol>
@@ -1370,8 +1372,8 @@ of data from the input {{ReadableStream}}, given a {{TextDecoder}} <var>dec</var
 <ol>
  <li><p>If the <a for=TextDecoder>do not flush flag</a> for <var>dec</var> is unset, set
  <var>dec's</var> <a for=TextDecoder>decoder</a> to a new <a for=/>decoder</a> for <var>dec</var>'s
- <a for=TextDecoder>encoding</a>, set <var>dec</var>'s <a for=TextDecoder>stream</a> to a new <a
- for=/>stream</a>, and unset <var>dec</var>'s <a for=TextDecoder>BOM seen flag</a>.
+ <a for=TextDecoder>encoding</a>, set <var>dec</var>'s <a for=TextDecoder>stream</a> to a new
+ <a for=/>stream</a>, and unset <var>dec</var>'s <a for=TextDecoder>BOM seen flag</a>.
 
  <li><p>Unset <var>dec</var>'s <a for=TextDecoder>do not flush flag</a>.
 
@@ -1388,7 +1390,8 @@ of data from the input {{ReadableStream}}, given a {{TextDecoder}} <var>dec</var
   <li><p>Let <var>controller</var> be <var>dec</var>'s
   <a for=TextDecoder>transform</a>.\[[transformStreamController]].
 
-  <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>, <var>outputChunk</var>).
+  <li><p>Call <a abstract-op>TransformStreamDefaultControllerEnqueue</a>(<var>controller</var>,
+  <var>outputChunk</var>).
 
   <li><p>Return a new promise resolved with undefined.
  </ol>
@@ -1409,9 +1412,9 @@ interface TextEncoder {
   [NewObject] Uint8Array encode(optional USVString input = "");
 };</pre>
 
-<p>A {{TextEncoder}} object has an associated <dfn for=TextEncoder>encoder</dfn>, <dfn
-for=TextEncoder>transform</dfn> (a {{TransformStream}} object) and <dfn for=TextEncoder>pending high
-surrogate</dfn> (initially unset).
+<p>A {{TextEncoder}} object has an associated <dfn for=TextEncoder>encoder</dfn>,
+<dfn for=TextEncoder>transform</dfn> (a {{TransformStream}} object) and
+<dfn for=TextEncoder>pending high surrogate</dfn> (initially unset).
 
 <p class="note no-backref">A {{TextEncoder}} object offers no <var>label</var> argument as it only
 supports <a>UTF-8</a>. It also offers no <code>stream</code> option as no <a for=/>encoder</a>
@@ -1436,7 +1439,8 @@ requires buffering of scalar values.
   <p>Returns a <a>writable stream</a> which accepts string chunks and runs them through
   <a>UTF-8</a>'s <a for=/>encoder</a> before making them available to {{TextEncoder/readable}}.
 
-  <p>Typically this will be used via the {{ReadableStream/pipeThrough()}} method on a {{ReadableStream}} source.
+  <p>Typically this will be used via the {{ReadableStream/pipeThrough()}} method on a
+  {{ReadableStream}} source.
 
 
   <pre class=example id=example-textencode-writable><code class=lang-javascript>
@@ -1464,8 +1468,8 @@ constructor, when invoked, must run these steps:
  <li><p>Let <var>flushAlgorithm</var> be an algorithm which runs the <a>encode and flush</a>
  algorithm with <var>enc</var>.
 
- <li><p>Let <var>transform</var> be the result of calling <a
- abstract-op>CreateTransformStream</a>(<var>startAlgorithm</var>, <var>transformAlgorithm</var>,
+ <li><p>Let <var>transform</var> be the result of calling
+ <a abstract-op>CreateTransformStream</a>(<var>startAlgorithm</var>, <var>transformAlgorithm</var>,
  <var>flushAlgorithm</var>).
 
  <li><p>Set <var>enc</var>'s <a for=TextEncoder>transform</a> to <var>transform</var>
@@ -1476,11 +1480,11 @@ constructor, when invoked, must run these steps:
 <p>The <dfn attribute for=TextEncoder><code>encoding</code></dfn> attribute's getter must return
 "<code>utf-8</code>".
 
-<p>The <dfn attribute for=TextEncoder><code>readable</code></dfn> attribute's getter must return <a
-for=TextEncoder>transform</a>.\[[readable]].
+<p>The <dfn attribute for=TextEncoder><code>readable</code></dfn> attribute's getter must return
+<a for=TextEncoder>transform</a>.\[[readable]].
 
-<p>The <dfn attribute for=TextEncoder><code>writable</code></dfn> attribute's getter must return <a
-for=TextEncoder>transform</a>.\[[writable]].
+<p>The <dfn attribute for=TextEncoder><code>writable</code></dfn> attribute's getter must return
+<a for=TextEncoder>transform</a>.\[[writable]].
 
 <p>The <dfn method for=TextEncoder><code>encode(<var>input</var>)</code></dfn> method, when invoked,
 must run these steps:
@@ -1496,8 +1500,8 @@ must run these steps:
  <li><p>If <a abstract-op>IsWritableStreamLocked</a>(<var>writable</var>) is true, then throw a
  {{TypeError}} exception.
 
- <p class="note">These steps are for consistent behaviour with the {{TextDecoder}} <a method
- for=TextDecoder><code>decode(<var>input</var>)</code></a> method.
+ <p class="note">These steps are for consistent behaviour with the {{TextDecoder}}
+ <a method for=TextDecoder><code>decode(<var>input</var>)</code></a> method.
 
  <li><p>Convert <var>input</var> to a <a for=/>stream</a>.
 
@@ -1538,8 +1542,8 @@ must run these steps:
 
  <li><p>Let <var>encoder</var> be <a>UTF-8</a>'s <a for=/>encoder</a>.
 
- <li><p>Let <var>controller</var> be <var>enc</var>'s <a
- for=TextEncoder>transform</a>.\[[transformStreamController]].
+ <li><p>Let <var>controller</var> be <var>enc</var>'s
+ <a for=TextEncoder>transform</a>.\[[transformStreamController]].
 
  <li><p>While true, run these steps:
 
@@ -1616,12 +1620,13 @@ strings.
 
   <li><p>Let <var>encoder</var> be <a>UTF-8</a>'s <a for=/>encoder</a>.
 
-  <li><p>Let <var>controller</var> be <var>enc</var>'s <a
-  for=TextEncoder>transform</a>.\[[transformStreamController]].
+  <li><p>Let <var>controller</var> be <var>enc</var>'s
+  <a for=TextEncoder>transform</a>.\[[transformStreamController]].
 
   <li><p>Let <var>token</var> be U+FFFD.
 
-  <li><p><a>Process</a> <var>token</var> for <var>encoder</var>, <var>input</var>, <var>output</var>.
+  <li><p><a>Process</a> <var>token</var> for <var>encoder</var>, <var>input</var>,
+  <var>output</var>.
 
   <li><p>Convert <var>output</var> into a byte sequence.
 

--- a/encoding.bs
+++ b/encoding.bs
@@ -1325,7 +1325,7 @@ method, when invoked, must run these steps:
  true, or <a abstract-op>IsSharedArrayBuffer</a>(<var>chunk</var>) is true, then return a new
  promise rejected with a {{TypeError}} exception.
 
- <li><p>If the <a for=TextDecoder>do not flush flag</a> for <var>dec</var> is unset, set
+ <li><p>If the <a for=TextDecoder>do not flush flag</a> for <var>dec</var> is unset, then set
  <var>dec's</var> <a for=TextDecoder>decoder</a> to a new <a for=/>decoder</a> for <var>dec</var>'s
  <a for=TextDecoder>encoding</a>, set <var>dec</var>'s <a for=TextDecoder>stream</a> to a new
  <a for=/>stream</a>, and unset <var>dec</var>'s <a for=TextDecoder>BOM seen flag</a>.
@@ -1363,7 +1363,7 @@ method, when invoked, must run these steps:
    <var>dec</var>'s <a for=TextDecoder>decoder</a>, <var>dec</var>'s <a for=TextDecoder>stream</a>,
    <var>output</var>, and <var>dec's</var> <a for=TextDecoder>error mode</a>.
 
-   <li><p>If <var>result</var> is <a>error</a>, return a new promise rejected with a
+   <li><p>If <var>result</var> is <a>error</a>, then return a new promise rejected with a
    {{TypeError}} exception.
   </ol>
 </ol>
@@ -1372,7 +1372,7 @@ method, when invoked, must run these steps:
 of data from the input {{ReadableStream}}, given a {{TextDecoder}} <var>dec</var>, runs these steps:
 
 <ol>
- <li><p>If the <a for=TextDecoder>do not flush flag</a> for <var>dec</var> is unset, set
+ <li><p>If the <a for=TextDecoder>do not flush flag</a> for <var>dec</var> is unset, then set
  <var>dec's</var> <a for=TextDecoder>decoder</a> to a new <a for=/>decoder</a> for <var>dec</var>'s
  <a for=TextDecoder>encoding</a>, set <var>dec</var>'s <a for=TextDecoder>stream</a> to a new
  <a for=/>stream</a>, and unset <var>dec</var>'s <a for=TextDecoder>BOM seen flag</a>.
@@ -1502,7 +1502,7 @@ must run these steps:
  <li><p>If <a abstract-op>IsWritableStreamLocked</a>(<var>writable</var>) is true, then throw a
  {{TypeError}} exception.
 
- <p class="note">These steps are for consistent behaviour with the {{TextDecoder}}
+ <p class="note">These steps are for consistent behavior with the {{TextDecoder}}
  <a method for=TextDecoder><code>decode(<var>input</var>)</code></a> method.
 
  <li><p>Convert <var>input</var> to a <a for=/>stream</a>.
@@ -1537,8 +1537,8 @@ must run these steps:
 
 <ol>
  <li><p>Let <var>input</var> be the result of <a lt="converted to an IDL value">converting</a>
- <var>chunk</var> to a {{DOMString}}. If this throws an exception, return a promise rejected with
- that exception.
+ <var>chunk</var> to a {{DOMString}}. If this throws an exception, then return a promise rejected
+ with that exception.
 
  <li><p>Convert <var>input</var> to a <a for=/>stream</a>.
 
@@ -1568,7 +1568,7 @@ must run these steps:
   <li><p>Let <var>result</var> be the result of executing the <a>convert code unit to scalar
   value</a> algorithm with <var>enc</var>, <var>token</var> and <var>input</var>.
 
-  <li><p>If <var>result</var> is not <a>continue</a>, <a>process</a> <var>result</var> for
+  <li><p>If <var>result</var> is not <a>continue</a>, then <a>process</a> <var>result</var> for
   <var>encoder</var>, <var>input</var>, <var>output</var>.
 
  </ol>
@@ -1586,19 +1586,19 @@ runs these steps:
 
   <li><p>Unset <var>enc</var>'s <a>pending high surrogate</a>.
 
-  <li><p>If <var>token</var> is in the range U+DC00 to U+DFFF, inclusive, return a code point whose
-  value is 0x10000 + ((<var>high surrogate</var> &minus; 0xD800) &lt;&lt; 10) + (<var>token</var>
-  &minus; 0xDC00).
+  <li><p>If <var>token</var> is in the range U+DC00 to U+DFFF, inclusive, then return a code point
+  whose value is 0x10000 + ((<var>high surrogate</var> &minus; 0xD800) &lt;&lt; 10) +
+  (<var>token</var> &minus; 0xDC00).
 
   <li><p><a>Prepend</a> <var>token</var> to <var>input</var>.
 
   <li><p>Return U+FFFD.
  </ol>
 
- <li><p>If <var>token</var> is in the range U+D800 to U+DBFF, inclusive, set <a>pending high
+ <li><p>If <var>token</var> is in the range U+D800 to U+DBFF, inclusive, then set <a>pending high
  surrogate</a> to <var>token</var> and return <a>continue</a>.
 
- <li><p>If <var>token</var> is in the range U+DC00 to U+DFFF, inclusive, return U+FFFD.
+ <li><p>If <var>token</var> is in the range U+DC00 to U+DFFF, inclusive, then return U+FFFD.
 
  <li><p>Return <var>token</var>.
 </ol>

--- a/encoding.bs
+++ b/encoding.bs
@@ -1474,7 +1474,7 @@ constructor, when invoked, must run these steps:
  <a abstract-op>CreateTransformStream</a>(<var>startAlgorithm</var>, <var>transformAlgorithm</var>,
  <var>flushAlgorithm</var>).
 
- <li><p>Set <var>enc</var>'s <a for=TextEncoder>transform</a> to <var>transform</var>
+ <li><p>Set <var>enc</var>'s <a for=TextEncoder>transform</a> to <var>transform</var>.
 
  <li><p>Return <var>enc</var>.
 </ol>
@@ -1606,9 +1606,9 @@ runs these steps:
  <li><p>Return <var>token</var>.
 </ol>
 
-<p class=note>This is equivalent to the <a spec=webidl>convert a DOMString to a sequence of Unicode
-scalar values</a> algorithm from [[WEBIDL]], but allows for surrogate pairs that are split between
-strings.
+<p class=note>This is equivalent to the "<a>convert</a> a <a>JavaScript string</a> into a <a>scalar
+value string</a>" algorithm from the Infra Standard, but allows for surrogate pairs that are split
+between strings.
 
 <p>The <dfn id=concept-te-encode-and-flush>encode and flush</dfn> algorithm, given a
 {{TextEncoder}} <var>enc</var>, runs these steps:


### PR DESCRIPTION
Add `readable` and `writable` attributes to TextEncoder and TextDecoder
objects to permit them to be used to transform ReadableStreams via the
`pipeThrough()` method.

This integrates the Encoding Standard with the Streams Standard. See
https://streams.spec.whatwg.org/#ts-model for the definition of a
"transform stream" and https://streams.spec.whatwg.org/#rs-pipe-through
for an explanation of the `pipeThrough()` method.

A TextEncoder object can be used to transform a stream of strings to a
stream of bytes in UTF-8 encoding. A TextDecoder object can be used to
transform a stream of bytes in the encoding passed to the constructor to
strings.

The implementation delegates to a TransformStream object internally,
which provides the glue logic that ties the `readable` and `writable`
together.

There is a human-readable version of these changes at
http://htmlpreview.github.io/?https://github.com/ricea/encoding-streams/blob/master/patch.html

There is a prollyfill and tests for the new functionality at
https://github.com/GoogleChromeLabs/text-encode-transform-prollyfill

Closes #72.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/127.html" title="Last updated on Mar 30, 2018, 10:29 AM GMT (c39d7a1)">Preview</a> | <a href="https://whatpr.org/encoding/127/f381389...c39d7a1.html" title="Last updated on Mar 30, 2018, 10:29 AM GMT (c39d7a1)">Diff</a>