### PR TITLE
gb18030 decoder: unset state before returning

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -2076,6 +2076,8 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
    ((<a>gb18030 second</a> &minus; 0x30) × (10 × 126)) +
    ((<a>gb18030 third</a> &minus; 0x81) × 10) + <var>byte</var> &minus; 0x30.
 
+   <li><p>Set <a>gb18030 first</a>, <a>gb18030 second</a>, and <a>gb18030 third</a> to 0x00.
+
    <li><p>If <var>code point</var> is null, return <a>error</a>.
 
    <li><p>Return a code point whose value is <var>code point</var>.
@@ -3156,6 +3158,7 @@ Boris Zbarsky,
 Bruno Haible,
 Cameron McCormack,
 Charles McCathieNeville,
+Christopher Foo,
 David Carlisle,
 Domenic Denicola,
 Dominique Hazaël-Massieux,


### PR DESCRIPTION
Due to an oversight in #111 the gb18030 decoder didn't always reset state before returning after a four-byte sequence.

Fixes #146.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/153.html" title="Last updated on Aug 30, 2018, 10:01 AM GMT (038dac4)">Preview</a> | <a href="https://whatpr.org/encoding/153/1c6f66a...038dac4.html" title="Last updated on Aug 30, 2018, 10:01 AM GMT (038dac4)">Diff</a>