### PR TITLE
ISO-2022-JP encoder: document an oddity

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -2650,6 +2650,15 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
 
 <h4 id=iso-2022-jp-encoder dfn export>ISO-2022-JP encoder</h4>
 
+<div class="note no-backref">
+ <p>The <a>ISO-2022-JP encoder</a> is the only <a for=/>encoder</a> for which the concetenation of
+ multiple outputs can result in an <a>error</a> when run through the <a>ISO-2022-JP decoder</a>.
+
+ <p class=example id=example-iso-2022-jp-encoder-oddity>Encoding U+00A5 gives 0x1B 0x28 0x4A 0x5C
+ 0x1B 0x28 0x42. Doing that twice, concatenating the results, and then decoding yields U+00A5 U+FFFD
+ U+00A5.
+</div>
+
 <p><a>ISO-2022-JP</a>'s <a for=/>encoder</a> has an associated
 <dfn>ISO-2022-JP encoder state</dfn> which is <dfn lt="ISO-2022-JP encoder ASCII">ASCII</dfn>,
 <dfn lt="ISO-2022-JP encoder Roman">Roman</dfn>, or

--- a/encoding.bs
+++ b/encoding.bs
@@ -2651,7 +2651,7 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
 <h4 id=iso-2022-jp-encoder dfn export>ISO-2022-JP encoder</h4>
 
 <div class="note no-backref">
- <p>The <a>ISO-2022-JP encoder</a> is the only <a for=/>encoder</a> for which the concetenation of
+ <p>The <a>ISO-2022-JP encoder</a> is the only <a for=/>encoder</a> for which the concatenation of
  multiple outputs can result in an <a>error</a> when run through the <a>ISO-2022-JP decoder</a>.
 
  <p class=example id=example-iso-2022-jp-encoder-oddity>Encoding U+00A5 gives 0x1B 0x28 0x4A 0x5C

--- a/encoding.bs
+++ b/encoding.bs
@@ -2652,7 +2652,8 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
 
 <div class="note no-backref">
  <p>The <a>ISO-2022-JP encoder</a> is the only <a for=/>encoder</a> for which the concatenation of
- multiple outputs can result in an <a>error</a> when run through the <a>ISO-2022-JP decoder</a>.
+ multiple outputs can result in an <a>error</a> when run through the corresponding
+ <a for=/>decoder</a>.
 
  <p class=example id=example-iso-2022-jp-encoder-oddity>Encoding U+00A5 gives 0x1B 0x28 0x4A 0x5C
  0x1B 0x28 0x42. Doing that twice, concatenating the results, and then decoding yields U+00A5 U+FFFD


### PR DESCRIPTION
At this point it does not seem worth it to require further implementation changes and risk compatibility issues, so instead document the quirk.

Closes #115.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/155.html" title="Last updated on Sep 2, 2018, 9:31 AM GMT (9efea42)">Preview</a> | <a href="https://whatpr.org/encoding/155/b579018...9efea42.html" title="Last updated on Sep 2, 2018, 9:31 AM GMT (9efea42)">Diff</a>