### PR TITLE
Suppress bad-Unicode HTML checker warnings

### DIFF
--- a/.htmlcheckerfilter
+++ b/.htmlcheckerfilter
@@ -1,0 +1,2 @@
+.*Text run is not in Unicode Normalization Form C.*
+.*Document uses the Unicode Private Use Area.*

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ local: encoding.bs
 
 deploy: encoding.bs
 	curl --remote-name --fail https://resources.whatwg.org/build/deploy.sh
-	CHECKER_FILTER="Text run is not in Unicode Normalization Form C\.|.*appears to be written in.*|.*Charmod C073.*" \
 	EXTRA_FILES="*.txt *.json *.css" \
 	POST_BUILD_STEP='python visualize.py "$$DIR/"' \
 	bash ./deploy.sh


### PR DESCRIPTION
This change adds an `.htmlcheckerfilter` file containing regular-expression patterns that causes some particular warnings to be suppressed when the https://github.com/whatwg/whatwg.org/blob/master/resources.whatwg.org/build/deploy.sh script invokes the HTML checker on the Encoding build output.

The particular warnings that get suppressed are:

* Text run is not in Unicode Normalization Form C.
* Document uses the Unicode Private Use Area(s), which should not be used in publicly exchanged documents. (Charmod C073)

Otherwise, without this change, deployment of the Encoding spec will fail, because the https://github.com/whatwg/whatwg.org/blob/master/resources.whatwg.org/build/deploy.sh script causes the HTML checker to be invoked with the --Werror argument, which causes warnings to be treated as errors, which in turn causes the HTML checker process to exit non-zero.

Fixes https://github.com/whatwg/encoding/issues/178
Relates to https://github.com/whatwg/encoding/pull/177