### PR TITLE
Editorial: require returned dictionary members

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -1293,8 +1293,8 @@ attribute's getter, when invoked, must return "<code>utf-8</code>".
 
 <pre class=idl>
 dictionary TextEncoderEncodeIntoResult {
-  unsigned long long read;
-  unsigned long long written;
+  required unsigned long long read;
+  required unsigned long long written;
 };
 
 [Constructor,


### PR DESCRIPTION
As they are never not set. See https://bugzilla.mozilla.org/show_bug.cgi?id=1580154 for context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/185.html" title="Last updated on Sep 12, 2019, 4:13 PM UTC (3924074)">Preview</a> | <a href="https://whatpr.org/encoding/185/8abcdaf...3924074.html" title="Last updated on Sep 12, 2019, 4:13 PM UTC (3924074)">Diff</a>