### PR TITLE
Clarify that encoding tokens are scalar values.

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -99,7 +99,7 @@ bitwise AND by "&amp;", and bitwise OR by "|".
 <hr>
 
 <p>A <dfn id=concept-token>token</dfn> is a piece of data, such as a <a>byte</a>
-or <a>code point</a>.
+or <a>scalar value</a>.
 
 <p>A <dfn id=concept-stream>stream</dfn> represents an ordered sequence of
 <a>tokens</a>. <dfn>End-of-stream</dfn> is a special
@@ -216,15 +216,24 @@ happening.
  <var>encoderDecoderInstance</var> is a <a for=/>decoder</a> instance, and "<code>fatal</code>"
  otherwise.
 
+ <li><p>Assert: if <var>encoderDecoderInstance</var> is an <a for=/>encoder</a> instance,
+ <var>token</var> is not a <a>surrogate</a>.
+
  <li><p>Let <var>result</var> be the result of running <var>encoderDecoderInstance</var>'s
  <a>handler</a> on <var>input</var> and <var>token</var>.
 
  <li><p>If <var>result</var> is <a>continue</a> or <a>finished</a>, return
  <var>result</var>.
 
- <li><p>Otherwise, if <var>result</var> is one or more
- <a>tokens</a>, <a>push</a>
- <var>result</var> to <var>output</var>.
+ <li>
+  <p>Otherwise, if <var>result</var> is one or more
+  <a>tokens</a>:
+
+  <ol>
+   <li><p>Assert: If <var>encoderDecoderInstance</var> is a <a for=/>decoder</a>
+   instance, <var>result</var> does not contain any <a>surrogates</a>.
+   <li><p><a>Push</a> <var>result</var> to <var>output</var>.
+  </ol>
 
  <li>
   <p>Otherwise, if <var>result</var> is <a>error</a>, switch on <var>mode</var> and
@@ -858,6 +867,10 @@ different format here, to be able to represent ranges.)
 
  <p>The <a>get an encoding</a> algorithm is to be used to turn a <a>label</a> into an
  <a for=/>encoding</a>.
+
+ <p>Standards are to ensure that the streams they pass to the <a for=/>encode</a> and
+ <a>UTF-8 encode</a> algorithms are effectively scalar value streams, i.e., they contain
+ no <a>surrogates</a>.
 </div>
 
 <p>To <dfn export>decode</dfn> a byte stream <var>stream</var> using
@@ -898,7 +911,7 @@ fallback encoding <var>encoding</var>, run these steps:
  <a>prepend</a> the last byte of <var>buffer</var> to
  <var>stream</var>.
 
- <li><p>Let <var>output</var> be a code point <a for=/>stream</a>.
+ <li><p>Let <var>output</var> be a scalar value <a for=/>stream</a>.
 
  <li><p><a>Run</a> <var>encoding</var>'s
  <a for=/>decoder</a> with <var>stream</var> and <var>output</var>.
@@ -918,7 +931,7 @@ these steps:
  <li><p>If <var>buffer</var> does not match 0xEF 0xBB 0xBF,
  <a>prepend</a> <var>buffer</var> to <var>stream</var>.
 
- <li><p>Let <var>output</var> be a code point <a for=/>stream</a>.
+ <li><p>Let <var>output</var> be a scalar value <a for=/>stream</a>.
 
  <li><p><a>Run</a> <a>UTF-8</a>'s
  <a for=/>decoder</a> with <var>stream</var> and <var>output</var>.
@@ -930,7 +943,7 @@ these steps:
 steps:
 
 <ol>
- <li><p>Let <var>output</var> be a code point <a for=/>stream</a>.
+ <li><p>Let <var>output</var> be a scalar value <a for=/>stream</a>.
 
  <li><p><a>Run</a> <a>UTF-8</a>'s
  <a for=/>decoder</a> with <var>stream</var> and <var>output</var>.
@@ -945,7 +958,7 @@ steps:
      -->
 
 <ol>
- <li><p>Let <var>output</var> be a code point stream.
+ <li><p>Let <var>output</var> be a scalar value stream.
 
  <li><p>Let <var>potentialError</var> be the result of <a>running</a>
  <a>UTF-8</a>'s <a for=/>decoder</a> with <var>stream</var>, <var>output</var>, and
@@ -958,7 +971,7 @@ steps:
 
 <hr>
 
-<p>To <dfn export>encode</dfn> a code point stream <var>stream</var> using
+<p>To <dfn export>encode</dfn> a scalar value stream <var>stream</var> using
 encoding <var>encoding</var>, run these steps:
 
 <ol>
@@ -979,7 +992,7 @@ encoding <var>encoding</var>, run these steps:
 [[URL]]
 [[HTML]]
 
-<p>To <dfn export>UTF-8 encode</dfn> a code point stream <var>stream</var>,
+<p>To <dfn export>UTF-8 encode</dfn> a scalar value stream <var>stream</var>,
 return the result of <a lt=encode for=/>encoding</a>
 <var>stream</var> using encoding <a>UTF-8</a>.
 
@@ -3278,6 +3291,7 @@ Adam Rice,
 Alan Chaney,
 Alexander Shtuchkin,
 Allen Wirfs-Brock,
+Andreu Botella,
 Aneesh Agrawal,
 Arkadiusz Michalski,
 Asmus Freytag,

--- a/encoding.bs
+++ b/encoding.bs
@@ -98,8 +98,8 @@ bitwise AND by "&amp;", and bitwise OR by "|".
 
 <hr>
 
-<p>A <dfn id=concept-token>token</dfn> is a piece of data, such as a <a>byte</a>
-or <a>scalar value</a>.
+<p>A <dfn id=concept-token>token</dfn> is a piece of data, such as a <a>byte</a> or
+<a>scalar value</a>.
 
 <p>A <dfn id=concept-stream>stream</dfn> represents an ordered sequence of
 <a>tokens</a>. <dfn>End-of-stream</dfn> is a special
@@ -226,12 +226,12 @@ happening.
  <var>result</var>.
 
  <li>
-  <p>Otherwise, if <var>result</var> is one or more
-  <a>tokens</a>:
+  <p>Otherwise, if <var>result</var> is one or more <a>tokens</a>:
 
   <ol>
-   <li><p>Assert: If <var>encoderDecoderInstance</var> is a <a for=/>decoder</a>
-   instance, <var>result</var> does not contain any <a>surrogates</a>.
+   <li><p>Assert: if <var>encoderDecoderInstance</var> is a <a for=/>decoder</a> instance,
+   <var>result</var> does not contain any <a>surrogates</a>.
+
    <li><p><a>Push</a> <var>result</var> to <var>output</var>.
   </ol>
 
@@ -869,8 +869,8 @@ different format here, to be able to represent ranges.)
  <a for=/>encoding</a>.
 
  <p>Standards are to ensure that the streams they pass to the <a for=/>encode</a> and
- <a>UTF-8 encode</a> algorithms are effectively scalar value streams, i.e., they contain
- no <a>surrogates</a>.
+ <a>UTF-8 encode</a> algorithms are effectively scalar value streams, i.e., they contain no
+ <a>surrogates</a>.
 </div>
 
 <p>To <dfn export>decode</dfn> a byte stream <var>stream</var> using
@@ -971,8 +971,8 @@ steps:
 
 <hr>
 
-<p>To <dfn export>encode</dfn> a scalar value stream <var>stream</var> using
-encoding <var>encoding</var>, run these steps:
+<p>To <dfn export>encode</dfn> a scalar value stream <var>stream</var> using encoding
+<var>encoding</var>, run these steps:
 
 <ol>
  <li><p>Assert: <var>encoding</var> is not <a>replacement</a>, <a>UTF-16BE</a> or
@@ -992,9 +992,8 @@ encoding <var>encoding</var>, run these steps:
 [[URL]]
 [[HTML]]
 
-<p>To <dfn export>UTF-8 encode</dfn> a scalar value stream <var>stream</var>,
-return the result of <a lt=encode for=/>encoding</a>
-<var>stream</var> using encoding <a>UTF-8</a>.
+<p>To <dfn export>UTF-8 encode</dfn> a scalar value stream <var>stream</var>, return the result of
+<a lt=encode for=/>encoding</a> <var>stream</var> using encoding <a>UTF-8</a>.
 
 
 


### PR DESCRIPTION
This change changes some of the previous occurrences of the term "code point" for "scalar value", since it might not be clear to passing readers that output streams from decoding and input streams to encoding cannot contain tokens which are surrogate code points.

I haven't replaced the term "code point" in the indices section or in the handlers for the different encodings because those sections are heavy on numerical operations on code points, which aren't necessarily well-defined on scalar values. But perhaps the switch in terminology is more confusing than replacing the term throughout.

Fixes #195.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/196.html" title="Last updated on Jan 20, 2020, 1:19 PM UTC (bd1331c)">Preview</a> | <a href="https://whatpr.org/encoding/196/b818a7f...bd1331c.html" title="Last updated on Jan 20, 2020, 1:19 PM UTC (bd1331c)">Diff</a>