### PR TITLE
Add a BOM sniffing hook for better integration with HTML

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -854,7 +854,7 @@ different format here, to be able to represent ranges.)
 <div class=note>
  <p>The algorithms defined below (<a>decode</a>, <a>UTF-8 decode</a>,
  <a>UTF-8 decode without BOM</a>, <a>UTF-8 decode without BOM or fail</a>, <a for=/>encode</a>,
- <a>UTF-8 encode</a> and <a>BOM sniff</a>) are intended for usage by other standards.
+ <a>UTF-8 encode</a>, and <a>BOM sniff</a>) are intended for usage by other standards.
 
  <p>For decoding, <a>UTF-8 decode</a> is to be used by new formats. For identifiers or byte
  sequences within a format or protocol, use <a>UTF-8 decode without BOM</a> or
@@ -862,8 +862,8 @@ different format here, to be able to represent ranges.)
 
  <p>For encoding, <a>UTF-8 encode</a> is to be used.
 
- <p>Standards are strongly discouraged from using <a>decode</a>, <a for=/>encode</a> and <a>BOM
- sniff</a>, except as needed for compatibility.
+ <p>Standards are strongly discouraged from using <a>decode</a>, <a for=/>encode</a>, and
+ <a>BOM sniff</a>, except as needed for compatibility.
 
  <p>The <a>get an encoding</a> algorithm is to be used to turn a <a>label</a> into an
  <a for=/>encoding</a>.
@@ -877,8 +877,10 @@ different format here, to be able to represent ranges.)
 fallback encoding <var>encoding</var>, run these steps:
 
 <ol>
- <li><p><a>BOM sniff</a> <var>stream</var>. If the result is not null, set <var>encoding</var> to
- the resulting value and let <var>BOMSeen</var> be true. Otherwise, let <var>BOMSeen</var> be false.
+ <li>
+  <p><a>BOM sniff</a> <var>stream</var>. If the result is not null, set <var>encoding</var> to
+  the resulting value and let <var>BOMSeen</var> be true. Otherwise, let <var>BOMSeen</var> be
+  false.
 
   <p class=note>For compatibility with deployed content, the byte order mark is more authoritative
   than anything else. In a context where HTTP is used this is in violation of the semantics of the
@@ -976,29 +978,31 @@ steps:
 <p>To <dfn export>BOM sniff</dfn> a byte stream <var>stream</var>, run these steps:
 
 <ol>
-  <li><p>Wait until <var>stream</var> has three bytes available or the <a>end-of-stream</a> has been
-  reached, whichever comes first.
+ <li><p>Wait until <var>stream</var> has three bytes available or the <a>end-of-stream</a> has been
+ reached, whichever comes first.
 
-  <li>
-    <p>For each of the rows in the table below, starting with the first
-    one and going down, if <var>stream</var> <a for="byte sequence">starts with</a>
-    the bytes given in the first column, return the <a for=/>encoding</a> given
-    in the cell in the second column of that row. Do not consume those bytes.
+ <li>
+  <p>For each of the rows in the table below, starting with the first
+  one and going down, if <var>stream</var> <a for="byte sequence">starts with</a>
+  the bytes given in the first column, return the <a for=/>encoding</a> given
+  in the cell in the second column of that row. Do not consume those bytes.
 
-    <table>
-    <tbody><tr><th>Byte order mark<th>Encoding
-    <tr><td>0xEF 0xBB 0xBF<td><a>UTF-8</a>
-    <tr><td>0xFE 0xFF<td><a>UTF-16BE</a>
-    <tr><td>0xFF 0xFE<td><a>UTF-16LE</a>
-    </table>
+  <table>
+   <tbody><tr><th>Byte order mark<th>Encoding
+   <tr><td>0xEF 0xBB 0xBF<td><a>UTF-8</a>
+   <tr><td>0xFE 0xFF<td><a>UTF-16BE</a>
+   <tr><td>0xFF 0xFE<td><a>UTF-16LE</a>
+  </table>
 
-  <li><p>Otherwise, return null.
+ <li><p>Otherwise, return null.
 </ol>
 
 <p class=note>This hook is a workaround for the fact that <a>decode</a> has no way to communicate
 back to the caller that it has found a byte order mark and is therefore not using the provided
 encoding. The hook is to be invoked before <a>decode</a>, and it will return an encoding
 corresponding to the byte order mark found, or null otherwise.
+
+
 
 <h2 id=api>API</h2>
 

--- a/encoding.bs
+++ b/encoding.bs
@@ -880,13 +880,13 @@ fallback encoding <var>encoding</var>, run these steps:
  <li><p>Let <var>BOMEncoding</var> be the result of <a>BOM sniffing</a> <var>stream</var>.
 
  <li>
-  <p>If <var>BOMEncoding</var> is not null:
+  <p>If <var>BOMEncoding</var> is non-null:
 
   <ol>
    <li><p>Set <var>encoding</var> to <var>BOMEncoding</var>.
 
-   <li><p>Read three bytes from <var>stream</var>, if <var>BOMEncoding</var> is <a>UTF-8</a>, or
-   two bytes otherwise. Do nothing with those bytes.
+   <li><p><a>Read</a> three bytes from <var>stream</var>, if <var>BOMEncoding</var> is <a>UTF-8</a>;
+   otherwise <a>read</a> two bytes. (Do nothing with those bytes.)
   </ol>
 
   <p class=note>For compatibility with deployed content, the byte order mark is more authoritative
@@ -986,10 +986,10 @@ steps:
  reached, whichever comes first.
 
  <li>
-  <p>For each of the rows in the table below, starting with the first
-  one and going down, if <var>stream</var> <a for="byte sequence">starts with</a>
-  the bytes given in the first column, return the <a for=/>encoding</a> given
-  in the cell in the second column of that row. Do not consume those bytes.
+  <p>For each of the rows in the table below, starting with the first one and going down, if
+  <var>stream</var> <a for="byte sequence">starts with</a> the bytes given in the first column,
+  return the <a for=/>encoding</a> given in the cell in the second column of that row. (Do not
+  consume those bytes.)
 
   <table>
    <tbody><tr><th>Byte order mark<th>Encoding
@@ -998,7 +998,7 @@ steps:
    <tr><td>0xFF 0xFE<td><a>UTF-16LE</a>
   </table>
 
- <li><p>Otherwise, return null.
+ <li><p>Return null.
 </ol>
 
 <p class=note>This hook is a workaround for the fact that <a>decode</a> has no way to communicate

--- a/encoding.bs
+++ b/encoding.bs
@@ -853,8 +853,8 @@ different format here, to be able to represent ranges.)
 
 <div class=note>
  <p>The algorithms defined below (<a>decode</a>, <a>UTF-8 decode</a>,
- <a>UTF-8 decode without BOM</a>, <a>UTF-8 decode without BOM or fail</a>, <a for=/>encode</a>, and
- <a>UTF-8 encode</a>) are intended for usage by other standards.
+ <a>UTF-8 decode without BOM</a>, <a>UTF-8 decode without BOM or fail</a>, <a for=/>encode</a>,
+ <a>UTF-8 encode</a> and <a>BOM sniff</a>) are intended for usage by other standards.
 
  <p>For decoding, <a>UTF-8 decode</a> is to be used by new formats. For identifiers or byte
  sequences within a format or protocol, use <a>UTF-8 decode without BOM</a> or
@@ -862,8 +862,8 @@ different format here, to be able to represent ranges.)
 
  <p>For encoding, <a>UTF-8 encode</a> is to be used.
 
- <p>Standards are strongly discouraged from using <a>decode</a> and <a for=/>encode</a>, except as
- needed for compatibility.
+ <p>Standards are strongly discouraged from using <a>decode</a>, <a for=/>encode</a> and <a>BOM
+ sniff</a>, except as needed for compatibility.
 
  <p>The <a>get an encoding</a> algorithm is to be used to turn a <a>label</a> into an
  <a for=/>encoding</a>.
@@ -877,39 +877,15 @@ different format here, to be able to represent ranges.)
 fallback encoding <var>encoding</var>, run these steps:
 
 <ol>
- <li><p>Let <var>buffer</var> be an empty byte sequence.
-
- <li><p>Let <var>BOMSeen</var> be false.
-
- <li><p><a>Read</a> bytes from <var>stream</var>
- into <var>buffer</var> until either <var>buffer</var> contains three bytes or
- <a>read</a> returns <a>end-of-stream</a>.
-
- <li>
-  <p>For each of the rows in the table below, starting with the first
-  one and going down, if the first bytes of <var>buffer</var> match
-  all the bytes given in the first column, then set <var>encoding</var>
-  to the <a for=/>encoding</a> given in the cell in the second column of
-  that row and <var>BOMSeen</var> to true.
-
-  <table>
-   <tbody><tr><th>Byte order mark<th>Encoding
-   <tr><td>0xEF 0xBB 0xBF<td><a>UTF-8</a>
-   <tr><td>0xFE 0xFF<td><a>UTF-16BE</a>
-   <tr><td>0xFF 0xFE<td><a>UTF-16LE</a>
-  </table>
+ <li><p><a>BOM sniff</a> <var>stream</var>. If the result is not null, set <var>encoding</var> to
+ the resulting value and let <var>BOMSeen</var> be true. Otherwise, let <var>BOMSeen</var> be false.
 
   <p class=note>For compatibility with deployed content, the byte order mark is more authoritative
   than anything else. In a context where HTTP is used this is in violation of the semantics of the
   `<code>Content-Type</code>` header.
 
- <li><p>If <var>BOMSeen</var> is false,
- <a>prepend</a> <var>buffer</var> to <var>stream</var>.
-
- <li><p>Otherwise, if <var>BOMSeen</var> is true, <var>encoding</var> is not
- <a>UTF-8</a>, and <var>buffer</var> contains three bytes,
- <a>prepend</a> the last byte of <var>buffer</var> to
- <var>stream</var>.
+ <li><p>If <var>BOMSeen</var> is true, <a>read</a> three bytes from <var>stream</var>, if
+ <var>encoding</var> is <a>UTF-8</a>, and two bytes otherwise. Do nothing with those bytes.
 
  <li><p>Let <var>output</var> be a scalar value <a for=/>stream</a>.
 
@@ -995,7 +971,34 @@ steps:
 <p>To <dfn export>UTF-8 encode</dfn> a scalar value stream <var>stream</var>, return the result of
 <a lt=encode for=/>encoding</a> <var>stream</var> using encoding <a>UTF-8</a>.
 
+<hr>
 
+<p>To <dfn export>BOM sniff</dfn> a byte stream <var>stream</var>, run these steps:
+
+<ol>
+  <li><p>Wait until <var>stream</var> has three bytes available or the <a>end-of-stream</a> has been
+  reached, whichever comes first.
+
+  <li>
+    <p>For each of the rows in the table below, starting with the first
+    one and going down, if <var>stream</var> <a for="byte sequence">starts with</a>
+    the bytes given in the first column, return the <a for=/>encoding</a> given
+    in the cell in the second column of that row. Do not consume those bytes.
+
+    <table>
+    <tbody><tr><th>Byte order mark<th>Encoding
+    <tr><td>0xEF 0xBB 0xBF<td><a>UTF-8</a>
+    <tr><td>0xFE 0xFF<td><a>UTF-16BE</a>
+    <tr><td>0xFF 0xFE<td><a>UTF-16LE</a>
+    </table>
+
+  <li><p>Otherwise, return null.
+</ol>
+
+<p class=note>This hook is a workaround for the fact that <a>decode</a> has no way to communicate
+back to the caller that it has found a byte order mark and is therefore not using the provided
+encoding. The hook is to be invoked before <a>decode</a>, and it will return an encoding
+corresponding to the byte order mark found, or null otherwise.
 
 <h2 id=api>API</h2>
 

--- a/encoding.bs
+++ b/encoding.bs
@@ -877,17 +877,21 @@ different format here, to be able to represent ranges.)
 fallback encoding <var>encoding</var>, run these steps:
 
 <ol>
+ <li><p>Let <var>BOMEncoding</var> be the result of <a>BOM sniffing</a> <var>stream</var>.
+
  <li>
-  <p><a>BOM sniff</a> <var>stream</var>. If the result is not null, set <var>encoding</var> to
-  the resulting value and let <var>BOMSeen</var> be true. Otherwise, let <var>BOMSeen</var> be
-  false.
+  <p>If <var>BOMEncoding</var> is not null:
+
+  <ol>
+   <li><p>Set <var>encoding</var> to <var>BOMEncoding</var>.
+
+   <li><p>Read three bytes from <var>stream</var>, if <var>BOMEncoding</var> is <a>UTF-8</a>, or
+   two bytes otherwise. Do nothing with those bytes.
+  </ol>
 
   <p class=note>For compatibility with deployed content, the byte order mark is more authoritative
   than anything else. In a context where HTTP is used this is in violation of the semantics of the
   `<code>Content-Type</code>` header.
-
- <li><p>If <var>BOMSeen</var> is true, <a>read</a> three bytes from <var>stream</var>, if
- <var>encoding</var> is <a>UTF-8</a>, and two bytes otherwise. Do nothing with those bytes.
 
  <li><p>Let <var>output</var> be a scalar value <a for=/>stream</a>.
 


### PR DESCRIPTION
This change moves the BOM splitting part of the decode hook into a separate hook which does not consume any bytes of the token stream.

This will allow fixing a long-standing issue in the HTML encoding sniffing algorithm with the document's character encoding being set to the wrong result when there is a BOM (see whatwg/html#1077).

Closes #128.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/203.html" title="Last updated on Mar 24, 2020, 8:24 AM UTC (ed1ec60)">Preview</a> | <a href="https://whatpr.org/encoding/203/64e63cc...ed1ec60.html" title="Last updated on Mar 24, 2020, 8:24 AM UTC (ed1ec60)">Diff</a>