### PR TITLE
Add more UTF-8, UTF-16BE, and UTF-16LE labels

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -3195,7 +3195,7 @@ its <a>is UTF-16BE decoder</a> set to true.
 
 <h3 id=utf-16le dfn export>UTF-16LE</h3>
 
-<p class="note no-backref">"<code>utf-16</code>" is a <a>labels</a> for <a>UTF-16LE</a> to deal with
+<p class="note no-backref">"<code>utf-16</code>" is a <a>label</a> for <a>UTF-16LE</a> to deal with
 deployed content.
 
 

--- a/encoding.bs
+++ b/encoding.bs
@@ -296,10 +296,13 @@ prescribes, as that is necessary to be compatible with deployed content.
  <tbody>
   <tr><th colspan=2><a href=#the-encoding>The Encoding</a>
   <tr>
-   <td rowspan=3><a>UTF-8</a>
+   <td rowspan=6><a>UTF-8</a>
    <td>"<code>unicode-1-1-utf-8</code>"
+  <tr><td>"<code>unicode11utf8</code>"
+  <tr><td>"<code>unicode20utf8</code>"
   <tr><td>"<code>utf-8</code>"
   <tr><td>"<code>utf8</code>"
+  <tr><td>"<code>x-unicode20utf8</code>"
  <tbody>
   <tr><th colspan=2><a href=#legacy-single-byte-encodings>Legacy single-byte encodings</a>
   <tr>
@@ -597,11 +600,17 @@ prescribes, as that is necessary to be compatible with deployed content.
   <tr><td>"<code>iso-2022-kr</code>"
   <tr><td>"<code>replacement</code>"
   <tr>
-   <td><a>UTF-16BE</a>
-   <td>"<code>utf-16be</code>"
+   <td rowspan=2><a>UTF-16BE</a>
+   <td>"<code>unicodefffe</code>"
+  <tr><td>"<code>utf-16be</code>"
   <tr>
-   <td rowspan=2><a>UTF-16LE</a>
-   <td>"<code>utf-16</code>"
+   <td rowspan=7><a>UTF-16LE</a>
+   <td>"<code>csunicode</code>"
+  <tr><td>"<code>iso-10646-ucs-2</code>"
+  <tr><td>"<code>ucs-2</code>"
+  <tr><td>"<code>unicode</code>"
+  <tr><td>"<code>unicodefeff</code>"
+  <tr><td>"<code>utf-16</code>"
   <tr><td>"<code>utf-16le</code>"
   <tr>
    <td><a>x-user-defined</a>
@@ -3186,9 +3195,8 @@ its <a>is UTF-16BE decoder</a> set to true.
 
 <h3 id=utf-16le dfn export>UTF-16LE</h3>
 
-<p class="note no-backref">Both "<code>utf-16</code>" and
-"<code>utf-16le</code>" are <a>labels</a> for
-<a>UTF-16LE</a> to deal with deployed content.
+<p class="note no-backref">"<code>utf-16</code>" is a <a>labels</a> for <a>UTF-16LE</a> to deal with
+deployed content.
 
 
 <h4 id=utf-16le-decoder dfn export>UTF-16LE decoder</h4>

--- a/encodings.json
+++ b/encodings.json
@@ -4,8 +4,11 @@
       {
         "labels": [
           "unicode-1-1-utf-8",
+          "unicode11utf8",
+          "unicode20utf8",
           "utf-8",
-          "utf8"
+          "utf8",
+          "x-unicode20utf8"
         ],
         "name": "UTF-8"
       }
@@ -433,12 +436,18 @@
       },
       {
         "labels": [
+          "unicodefffe",
           "utf-16be"
         ],
         "name": "UTF-16BE"
       },
       {
         "labels": [
+          "csunicode",
+          "iso-10646-ucs-2",
+          "ucs-2",
+          "unicode",
+          "unicodefeff",
           "utf-16",
           "utf-16le"
         ],


### PR DESCRIPTION
Blink and WebKit have supported these for a long time.

Tests: https://github.com/web-platform-tests/wpt/pull/23427.

Fixes #168.

<!--
Thank you for contributing to the Encoding Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Presumably Chrome/Safari
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * See above.
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: N/A
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1635779
   * Safari: N/A

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/211.html" title="Last updated on May 6, 2020, 2:22 PM UTC (a39de01)">Preview</a> | <a href="https://whatpr.org/encoding/211/3911f81...a39de01.html" title="Last updated on May 6, 2020, 2:22 PM UTC (a39de01)">Diff</a>