### PR TITLE
Editorial: remove a lone close parenthesis

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -1129,7 +1129,7 @@ interface mixin TextDecoderCommon {
  <dd>A boolean, initially false.
 
  <dt><dfn id=textdecoder-error-mode for=TextDecoderCommon>error mode</dfn>
- <dd>An <a for=/>error mode</a>, initially "<code>replacement</code>").
+ <dd>An <a for=/>error mode</a>, initially "<code>replacement</code>".
 </dl>
 
 <p>The <dfn id=concept-td-serialize>serialize stream</dfn> algorithm, given a {{TextDecoderCommon}}


### PR DESCRIPTION
This was left over from #175.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/216.html" title="Last updated on May 29, 2020, 2:05 PM UTC (893f58b)">Preview</a> | <a href="https://whatpr.org/encoding/216/dd8e302...893f58b.html" title="Last updated on May 29, 2020, 2:05 PM UTC (893f58b)">Diff</a>