### PR TITLE
Editorial: Fix the type of the output argument to encode / UTF-8 encode

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -1063,8 +1063,8 @@ given an optional I/O queue of scalar values <var>output</var> (default « »), 
 <hr>
 
 <p>To <dfn export>encode</dfn> an I/O queue of scalar values <var>ioQueue</var> given an encoding
-<var>encoding</var> and an optional I/O queue of scalar values <var>output</var> (default « »), run
-these steps:
+<var>encoding</var> and an optional I/O queue of bytes <var>output</var> (default « »), run these
+steps:
 
 <ol>
  <li><p>Assert: <var>encoding</var> is not <a>replacement</a> or <a>UTF-16BE/LE</a>.
@@ -1082,7 +1082,7 @@ these steps:
 [[HTML]]
 
 <p>To <dfn export>UTF-8 encode</dfn> an I/O queue of scalar values <var>ioQueue</var> given an
-optional I/O queue of scalar values <var>output</var> (default « »), return the result of
+optional I/O queue of bytes <var>output</var> (default « »), return the result of
 <a lt=encode for=/>encoding</a> <var>ioQueue</var> with encoding <a>UTF-8</a> and <var>output</var>.
 
 <hr>


### PR DESCRIPTION
See https://github.com/whatwg/encoding/pull/215#issuecomment-690023201


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/229.html" title="Last updated on Sep 10, 2020, 7:01 AM UTC (1d07883)">Preview</a> | <a href="https://whatpr.org/encoding/229/4d43132...1d07883.html" title="Last updated on Sep 10, 2020, 7:01 AM UTC (1d07883)">Diff</a>