### PR TITLE
Minor correction to a tool script: raise does not work like print

### DIFF
--- a/tools-clean.py
+++ b/tools-clean.py
@@ -11,7 +11,7 @@ for set in data:
         encoding["labels"] = labels
         for label in labels:
             if label in labelsseen:
-                raise("Duplicate label: ", label)
+                raise ValueError("Duplicate label: {!r}".format(label))
             labelsseen.append(label)
 
 handle = open(filename, "w")


### PR DESCRIPTION
The previous `raise "Duplicate label:", label` used in earlier revisions of this script would have worked up to and including Python 2.5, since exception types could be strings (with the exception message kept around separately) for legacy reasons, since class-based exceptions were only added in Python 1.5 (in 1997); i.e. `"Duplicate label:` would still be accepted as an exception type (although the colon would be redundant to the one inserted between the exception type and value in the traceback).

This ability was removed in Python 2.6. The use of something like `raise ValueError, ("Duplicate label: %r" % label)` would have been okay up to and including Python 2.7; however, due to the removal of string exception types, the syntax for passing the class and value (as opposed to passing an instance) was not retained in Python 3.0, necessitating the use of `raise ValueError("Duplicate label: %r" % label)`—or, with new-style format strings, `raise ValueError("Duplicate label: {!r}".format(label))`.

The `raise` statement is still a flow control keyword, not a function (unlike `print` and `exec`).

<!--
Thank you for contributing to the Encoding Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
