### PR TITLE
Fix typo

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -1007,7 +1007,7 @@ queue of scalar values <var>output</var> (default « »), run these steps:
 optional I/O queue of scalar values <var>output</var> (default « »), run these steps:
 
 <ol>
- <li><p><a>Process a queue</a> wih an instance of <a>UTF-8</a>'s <a for=/>decoder</a>,
+ <li><p><a>Process a queue</a> with an instance of <a>UTF-8</a>'s <a for=/>decoder</a>,
  <var>ioQueue</var>, <var>output</var>, and "<code>replacement</code>".
 
  <li><p>Return <var>output</var>.


### PR DESCRIPTION
I replaced `wih` by `with`. That’s it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/255.html" title="Last updated on Mar 2, 2021, 10:47 PM UTC (81fe160)">Preview</a> | <a href="https://whatpr.org/encoding/255/26f6e56...81fe160.html" title="Last updated on Mar 2, 2021, 10:47 PM UTC (81fe160)">Diff</a>