### PR TITLE
Editorial: Use "set up" for TransformStreams rather than "create"

### DIFF
--- a/.htmlcheckerfilter
+++ b/.htmlcheckerfilter
@@ -1,3 +1,4 @@
 .*Text run is not in Unicode Normalization Form C.*
 .*Document uses the Unicode Private Use Area.*
 .*File was not checked. Files must have .html, .xhtml, .htm, or .xht extensions.*
+.*Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.).*

--- a/.htmlcheckerfilter
+++ b/.htmlcheckerfilter
@@ -1,4 +1,4 @@
 .*Text run is not in Unicode Normalization Form C.*
 .*Document uses the Unicode Private Use Area.*
 .*File was not checked. Files must have .html, .xhtml, .htm, or .xht extensions.*
-.*Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.).*
+.*Possible misuse of “aria-label”. \(If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.\).*

--- a/encoding.bs
+++ b/encoding.bs
@@ -1731,7 +1731,7 @@ constructor steps are:
  <li><p>If <var>options</var>["{{TextDecoderOptions/fatal}}"] is true, then set <a>this</a>'s
  <a for=TextDecoderCommon>error mode</a> to "<code>fatal</code>".
 
- <li><p>set <a>this</a>'s <a for=TextDecoderCommon>ignore BOM</a> to
+ <li><p>Set <a>this</a>'s <a for=TextDecoderCommon>ignore BOM</a> to
  <var>options</var>["{{TextDecoderOptions/ignoreBOM}}"].
 
  <li><p>Set <a>this</a>'s <a for=TextDecoderCommon>decoder</a> to a new instance of <a>this</a>'s
@@ -1744,12 +1744,15 @@ constructor steps are:
  <li><p>Let <var>flushAlgorithm</var> be an algorithm which takes no arguments and runs the
  <a>flush and enqueue</a> algorithm with <a>this</a>.
 
- <li><p>Set <a>this</a>'s <a for=GenericTransformStream>transform</a> to the result of
- <a for=TransformStream>creating</a> a {{TransformStream}} with
- <a for=TransformStream/create><var ignore>transformAlgorithm</var></a> set to
+ <li><p>Let <var>transformStream</var> be a [=new=] {{TransformStream}}.
+
+ <li><p>[=TransformStream/Set up=] <var>transformStream</var> with
+ <a for="TransformStream/set up"><var ignore>transformAlgorithm</var></a> set to
  <var>transformAlgorithm</var> and
- <a for=TransformStream/create><var ignore>flushAlgorithm</var></a> set to
+ <a for="TransformStream/set up"><var ignore>flushAlgorithm</var></a> set to
  <var>flushAlgorithm</var>.
+
+ <li><p>Set <a>this</a>'s <a for=GenericTransformStream>transform</a> to <var>transformStream</var>.
 </ol>
 
 <p>The <dfn>decode and enqueue a chunk</dfn> algorithm, given a {{TextDecoderStream}} object
@@ -1892,12 +1895,15 @@ constructor steps are:
  <li><p>Let <var>flushAlgorithm</var> be an algorithm which runs the <a>encode and flush</a>
  algorithm with <a>this</a>.
 
- <li><p>Set <a>this</a>'s <a for=GenericTransformStream>transform</a> to the result of
- <a for=TransformStream>creating</a> a {{TransformStream}} with
- <a for=TransformStream/create><var ignore>transformAlgorithm</var></a> set to
+ <li><p>Let <var>transformStream</var> be a [=new=] {{TransformStream}}.
+
+ <li><p>[=TransformStream/Set up=] <var>transformStream</var> with
+ <a for="TransformStream/set up"><var ignore>transformAlgorithm</var></a> set to
  <var>transformAlgorithm</var> and
- <a for=TransformStream/create><var ignore>flushAlgorithm</var></a> set to
+ <a for="TransformStream/set up"><var ignore>flushAlgorithm</var></a> set to
  <var>flushAlgorithm</var>.
+
+ <li><p>Set <a>this</a>'s <a for=GenericTransformStream>transform</a> to <var>transformStream</var>.
 </ol>
 
 <hr>


### PR DESCRIPTION
Follows whatwg/streams#1110.

I just noticed that the Encoding standard was failing to build because of these changes to the Streams standards.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/260.html" title="Last updated on Jun 21, 2021, 8:56 AM UTC (cb41266)">Preview</a> | <a href="https://whatpr.org/encoding/260/75b988c...cb41266.html" title="Last updated on Jun 21, 2021, 8:56 AM UTC (cb41266)">Diff</a>