### PR TITLE
Editorial: use new Web IDL primitives for Uint8Array writing

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -1572,10 +1572,6 @@ method steps are:
 
  <li><p>Let <var>written</var> be 0.
 
- <li><p>Let <var>destinationBytes</var> be the result of
- <a lt="get a reference to the buffer source">getting a reference to the bytes held by</a>
- <var>destination</var>.
-
  <li><p>Let <var>encoder</var> be an instance of the <a>UTF-8 encoder</a>.
 
  <li>
@@ -1603,7 +1599,7 @@ method steps are:
 
     <ol>
      <li>
-      <p>If <var>destinationBytes</var>'s <a for="byte sequence">length</a> &minus;
+      <p>If <var>destination</var>'s <a for="BufferSource">byte length</a> &minus;
       <var>written</var> is greater than or equal to the number of bytes in <var>result</var>, then:
 
       <ol>
@@ -1612,7 +1608,8 @@ method steps are:
        <li><p>Otherwise, increment <var>read</var> by 1.
 
        <li>
-        <p>Write the bytes in <var>result</var> into <var>destinationBytes</var>, from byte offset
+        <p><a for="ArrayBufferView">Write</a> the bytes in <var>result</var> into
+        <var>destination</var>, with <a for="ArrayBufferView/write"><i>startingOffset</i> set to
         <var>written</var>.
 
         <p class=warning>See the

--- a/encoding.bs
+++ b/encoding.bs
@@ -1609,7 +1609,7 @@ method steps are:
 
        <li>
         <p><a for="ArrayBufferView">Write</a> the bytes in <var>result</var> into
-        <var>destination</var>, with <a for="ArrayBufferView/write"><i>startingOffset</i> set to
+        <var>destination</var>, with <a for="ArrayBufferView/write"><i>startingOffset</i></a> set to
         <var>written</var>.
 
         <p class=warning>See the


### PR DESCRIPTION
Follows https://github.com/heycam/webidl/pull/987.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/262.html" title="Last updated on Sep 27, 2021, 1:25 PM UTC (ad400cd)">Preview</a> | <a href="https://whatpr.org/encoding/262/b74cc91...ad400cd.html" title="Last updated on Sep 27, 2021, 1:25 PM UTC (ad400cd)">Diff</a>