### PR TITLE
Fix TextDecoderStream's behavior when processing the end of stream

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -1810,23 +1810,35 @@ steps:
  <li><p>Let <var>output</var> be the <a for=/>I/O queue</a> of scalar values
  « <a>end-of-queue</a> ».
 
- <li><p>Let <var>result</var> be the result of <a>processing an item</a> with <a>end-of-queue</a>,
- <var>decoder</var>'s <a for=TextDecoderCommon>decoder</a>, <var>decoder</var>'s
- <a for=TextDecoderCommon>I/O queue</a>, <var>output</var>, and <var>decoder</var>'s
- <a for=TextDecoderCommon>error mode</a>.
-
  <li>
-  <p>If <var>result</var> is <a>finished</a>, then:
+  <p>While true:
 
   <ol>
-   <li><p>Let <var>outputChunk</var> be the result of running <a>serialize I/O queue</a> with
-   <var>decoder</var> and <var>output</var>.
+   <li><p>Let <var>item</var> be the result of <a>reading</a> from <var>decoder</var>'s
+   <a for=TextDecoderCommon>I/O queue</a>.
 
-   <li><p>If <var>outputChunk</var> is non-empty, then <a for=TransformStream>enqueue</a>
-   <var>outputChunk</var> in <var>decoder</var>'s <a for=GenericTransformStream>transform</a>.
+   <li><p>Let <var>result</var> be the result of <a>processing an item</a> with <var>item</var>,
+   <var>decoder</var>'s <a for=TextDecoderCommon>decoder</a>, <var>decoder</var>'s
+   <a for=TextDecoderCommon>I/O queue</a>, <var>output</var>, and <var>decoder</var>'s
+   <a for=TextDecoderCommon>error mode</a>.
+
+   <li>
+    <p>If <var>result</var> is finished, then:
+
+    <ol>
+     <li><p>Let <var>outputChunk</var> be the result of running <a>serialize I/O queue</a> with
+     <var>decoder</var> and <var>output</var>.
+
+     <li><p>If <var>outputChunk</var> is non-empty, then <a for=TransformStream>enqueue</a>
+     <var>outputChunk</var> in <var>decoder</var>'s <a for=GenericTransformStream>transform</a>.
+
+     <li><p>Return.
+    </ol>
+   </li>
+
+   <li><p>Otherwise, if <var>result</var> is <a>error</a>, <a>throw</a> a {{TypeError}}.
   </ol>
-
- <li><p>Otherwise, <a>throw</a> a {{TypeError}}.
+ </li>
 </ol>
 
 

--- a/encoding.bs
+++ b/encoding.bs
@@ -1823,7 +1823,7 @@ steps:
    <a for=TextDecoderCommon>error mode</a>.
 
    <li>
-    <p>If <var>result</var> is finished, then:
+    <p>If <var>result</var> is <a>finished</a>, then:
 
     <ol>
      <li><p>Let <var>outputChunk</var> be the result of running <a>serialize I/O queue</a> with


### PR DESCRIPTION
This change fixes `TextDecoderStream`'s "flush and enqueue" algorithm to handle the end of the stream in the same way as a call to `TextDecoder`'s `decode` method with no parameters.

Fixes #263.

<!--
Thank you for contributing to the Encoding Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [X] At least two implementers are interested (and none opposed):
   * Firefox and Safari implement this.
   * Chrome has bugs around end-of-stream handling, but they are shared with `TextDecoder`'s non-streaming mode.
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=978522
   * Firefox: N/A
   * Safari: N/A

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/265.html" title="Last updated on Jun 21, 2021, 11:04 AM UTC (ed72ecb)">Preview</a> | <a href="https://whatpr.org/encoding/265/395efaf...ed72ecb.html" title="Last updated on Jun 21, 2021, 11:04 AM UTC (ed72ecb)">Diff</a>