### PR TITLE
Editorial: Fix instances of prepend used with an end-of-queue item

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -2832,9 +2832,7 @@ and <var>code point</var>, runs these steps:
 
    <dt><a>end-of-queue</a>
    <dd><p>Set the <a>ISO-2022-JP decoder state</a> to
-   <a lt="ISO-2022-JP decoder lead byte">lead byte</a>,
-   <a>prepend</a> <var>byte</var> to
-   <var>ioQueue</var>, and return <a>error</a>.
+   <a lt="ISO-2022-JP decoder lead byte">lead byte</a> and return <a>error</a>.
 
    <dt>Otherwise
    <dd><p>Set <a>ISO-2022-JP decoder state</a> to
@@ -2852,7 +2850,8 @@ and <var>code point</var>, runs these steps:
    <a lt="ISO-2022-JP decoder escape">escape</a>, and return
    <a>continue</a>.
 
-   <li><p><a>Prepend</a> <var>byte</var> to <var>ioQueue</var>.
+   <li><p>If <var>byte</var> is not <a>end-of-queue</a>, then <a>prepend</a>
+   <var>byte</var> to <var>ioQueue</var>.
 
    <li><p>Set <a>ISO-2022-JP output</a> to false,
    <a>ISO-2022-JP decoder state</a> to
@@ -2895,7 +2894,9 @@ and <var>code point</var>, runs these steps:
      <a>error</a> otherwise.
     </ol>
 
-   <li><p><a>Prepend</a> <var>lead</var> and <var>byte</var> to <var>ioQueue</var>.
+   <li><p>If <var>byte</var> is <a>end-of-queue</a>, then <a>prepend</a>
+   <var>lead</var> to <var>ioQueue</var>. Otherwise, <a>prepend</a>
+   <var>lead</var> and <var>byte</var> to <var>ioQueue</var>.
 
    <li><p>Set <a>ISO-2022-JP output</a> to false,
    <a>ISO-2022-JP decoder state</a> to <a>ISO-2022-JP decoder output state</a>
@@ -2928,9 +2929,8 @@ and <var>code point</var>, runs these steps:
 <ol>
  <li><p>If <var>code point</var> is <a>end-of-queue</a> and
  <a>ISO-2022-JP encoder state</a> is not
- <a lt="ISO-2022-JP encoder ASCII">ASCII</a>,
- <a>prepend</a> <var>code point</var> to
- <var>ioQueue</var>, set <a>ISO-2022-JP encoder state</a> to
+ <a lt="ISO-2022-JP encoder ASCII">ASCII</a>, set
+ <a>ISO-2022-JP encoder state</a> to
  <a lt="ISO-2022-JP encoder ASCII">ASCII</a>, and return three bytes
  0x1B 0x28 0x42.
 


### PR DESCRIPTION
At various times in the ISO-2022-JP decoder and encoder, the prepend operation was being called with an end-of-queue item, even though that was made illegal in #215. This change removes those instances, in order to keep the same behavior as before #215.

This was discovered in #263.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/266.html" title="Last updated on Jun 21, 2021, 11:03 AM UTC (caf80f5)">Preview</a> | <a href="https://whatpr.org/encoding/266/395efaf...caf80f5.html" title="Last updated on Jun 21, 2021, 11:03 AM UTC (caf80f5)">Diff</a>