### PR TITLE
Clarify insertion order when prepending multiple bytes at once to ioQueue

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -2339,7 +2339,7 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
     <p>If <var>byte</var> is not in the range 0x30 to 0x39, inclusive, then:
 
     <ol>
-     <li><p><a>Prepend</a> <a>gb18030 second</a>, <a>gb18030 third</a>, and <var>byte</var> to
+     <li><p><a>Prepend</a> a sequence of <a>gb18030 second</a>, <a>gb18030 third</a>, and <var>byte</var> to
      <var>ioQueue</var>.
 
      <li><p>Set <a>gb18030 first</a>, <a>gb18030 second</a>, and <a>gb18030 third</a> to 0x00.
@@ -2366,7 +2366,7 @@ consumers of content generated with <a>GBK</a>'s <a for=/>encoder</a>.
    <li><p>If <var>byte</var> is in the range 0x81 to 0xFE, inclusive, set
    <a>gb18030 third</a> to <var>byte</var> and return <a>continue</a>.
 
-   <li><p><a>Prepend</a> <a>gb18030 second</a>
+   <li><p><a>Prepend</a> a sequence of <a>gb18030 second</a>
    followed by <var>byte</var> to <var>ioQueue</var>, set
    <a>gb18030 first</a> and <a>gb18030 second</a> to 0x00, and return
    <a>error</a>.
@@ -2899,7 +2899,7 @@ and <var>code point</var>, runs these steps:
     </ol>
 
    <li><p>If <var>byte</var> is <a>end-of-queue</a>, then <a>prepend</a>
-   <var>lead</var> to <var>ioQueue</var>. Otherwise, <a>prepend</a>
+   <var>lead</var> to <var>ioQueue</var>. Otherwise, <a>prepend</a> a sequence of
    <var>lead</var> and <var>byte</var> to <var>ioQueue</var>.
 
    <li><p>Set <a>ISO-2022-JP output</a> to false,


### PR DESCRIPTION
Main source of confusion for me was the absence of the keyword "sequence". This PR fixes that.
Fixes #325.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/326.html" title="Last updated on Mar 3, 2024, 9:59 AM UTC (0575ad0)">Preview</a> | <a href="https://whatpr.org/encoding/326/b53fc98...0575ad0.html" title="Last updated on Mar 3, 2024, 9:59 AM UTC (0575ad0)">Diff</a>