### PR TITLE
Editorial: correct "is empty" reference

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -116,7 +116,7 @@ present in <a for=/>I/O queues</a> of any type and it signifies that there are n
 <a for=/>I/O queue</a> <var>ioQueue</var>, run these steps:
 
 <ol>
- <li><p>If <var>ioQueue</var> is <a for=list>empty</a>, then wait until its <a for=list>size</a> is
+ <li><p>If <var>ioQueue</var> <a for=list>is empty</a>, then wait until its <a for=list>size</a> is
  at least 1.
 
  <li><p>If <var>ioQueue</var>[0] is <a>end-of-queue</a>, then return <a>end-of-queue</a>.

--- a/encoding.bs
+++ b/encoding.bs
@@ -128,7 +128,7 @@ present in <a for=/>I/O queues</a> of any type and it signifies that there are n
 <var>ioQueue</var>, run these steps:
 
 <ol>
- <li><p>Let <var>readItems</var> be an empty list.
+ <li><p>Let <var>readItems</var> be « ».
 
  <li>
   <p>Perform the following step <var>number</var> times:
@@ -152,7 +152,7 @@ from an <a for=/>I/O queue</a> <var>ioQueue</var>, run these steps:
  <var>number</var>, or <var>ioQueue</var> <a for=list>contains</a> <a>end-of-queue</a>, whichever
  comes first.
 
- <li><p>Let <var>prefix</var> be an empty list.
+ <li><p>Let <var>prefix</var> be « ».
 
  <li>
   <p><a for=list>For each</a> <var>n</var> in <a>the range</a> 1 to <var>number</var>, inclusive:


### PR DESCRIPTION
Fixes #329.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/330.html" title="Last updated on Jun 13, 2024, 2:17 PM UTC (38eb3a2)">Preview</a> | <a href="https://whatpr.org/encoding/330/239008d...38eb3a2.html" title="Last updated on Jun 13, 2024, 2:17 PM UTC (38eb3a2)">Diff</a>