### PR TITLE
Add support for `[AllowResizable]` inputs

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -1459,7 +1459,7 @@ dictionary TextDecodeOptions {
 interface TextDecoder {
   constructor(optional DOMString label = "utf-8", optional TextDecoderOptions options = {});
 
-  USVString decode(optional AllowSharedBufferSource input, optional TextDecodeOptions options = {});
+  USVString decode(optional [AllowResizable] AllowSharedBufferSource input, optional TextDecodeOptions options = {});
 };
 TextDecoder includes TextDecoderCommon;
 </pre>
@@ -1621,7 +1621,7 @@ interface TextEncoder {
   constructor();
 
   [NewObject] Uint8Array encode(optional USVString input = "");
-  TextEncoderEncodeIntoResult encodeInto(USVString source, [AllowShared] Uint8Array destination);
+  TextEncoderEncodeIntoResult encodeInto(USVString source, [AllowResizable, AllowShared] Uint8Array destination);
 };
 TextEncoder includes TextEncoderCommon;
 </pre>


### PR DESCRIPTION
Add support for `[AllowResizable]` inputs

- [ ] At least two implementers are interested (and none opposed):
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/58636
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/494350642
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2024868
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=310341
   * Deno: N/A (accidentally works already)
   * Node.js: N/A (accidentally works already)
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A (no documentation for `SharedArrayBuffer` either)
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

Resolves #344.