### PR TITLE
Editorial: separate `TextDecoderStream` constructor to two algos

### DIFF
--- a/encoding.bs
+++ b/encoding.bs
@@ -1865,7 +1865,7 @@ constructor steps are:
 an optional <a for=/>error mode</a> <var>errorMode</var> (default "<code>replacement</code>"), and
 an optional boolean <var>ignoreBOM</var> (default false), run these steps:
 <ol>
- <li><p><a>Assert</a>: <var>encoding</var> is not <code>replacement</code>.
+ <li><p><a>Assert</a>: <var>encoding</var> is not <a>replacement</a>.
 
  <li><p>Set <var>stream</var>'s <a for=TextDecoderCommon>encoding</a> to <var>encoding</var>.
 

--- a/encoding.bs
+++ b/encoding.bs
@@ -1851,31 +1851,40 @@ constructor steps are:
 
  <li><p>If <var>encoding</var> is failure or <a>replacement</a>, then <a>throw</a> a {{RangeError}}.
 
- <li><p>Let <var>errorMode</var> be <code>fatal</code> if <var>options</var>["{{TextDecoderOptions/fatal}}"] is true; otherwise <code>replacement</code>.
+ <li><p>Let <var>errorMode</var> be "<code>fatal</code>" if
+ <var>options</var>["{{TextDecoderOptions/fatal}}"] is true; otherwise "<code>replacement</code>".
 
- <li><p>Let <var>ignoreBOM</var> be true if <var>options</var>["{{TextDecoderOptions/ignoreBOM}}"] is true; otherwise false.
-
- <li><p><a>Set up a text decoder stream</a> with <a>this</a>, <var>encoding</var>, <var>errorMode</var>, and <var>ignoreBOM</var>.
-
+ <li><p><a>Set up a text decoder stream</a> with <a>this</a>, <var>encoding</var>,
+ <var>errorMode</var>, and <var>options</var>["{{TextDecoderOptions/ignoreBOM}}"].
 </ol>
 </div>
 
 <div algorithm>
-<p>To <dfn export>set up a text decoder stream</dfn> <var>stream</var>, given an optional [=/encoding=] <var>encoding</var> (default <a>UTF-8</a>),
-an optional <a for=/>error mode</a> <var>errorMode</var> (default <code>replacement</code>), and an optional boolean <var>ignoreBOM</var> (default false), run these steps:
-
+<p>To <dfn export>set up a text decoder stream</dfn> <var>stream</var>, given a
+{{TextDecoderStream}} stream, an optional [=/encoding=] <var>encoding</var> (default <a>UTF-8</a>),
+an optional <a for=/>error mode</a> <var>errorMode</var> (default "<code>replacement</code>"), and
+an optional boolean <var>ignoreBOM</var> (default false), run these steps:
 <ol>
+ <li><p><a>Assert</a>: <var>encoding</var> is not <code>replacement</code>.
+
  <li><p>Set <var>stream</var>'s <a for=TextDecoderCommon>encoding</a> to <var>encoding</var>.
 
  <li><p>Set <var>stream</var>'s <a for=TextDecoderCommon>error mode</a> to <var>errorMode</var>.
 
  <li><p>Set <var>stream</var>'s <a for=TextDecoderCommon>ignore BOM</a> to <var>ignoreBOM</var>.
 
- <li><p>Let <var>transformAlgorithm</var> be an algorithm which takes a <var>chunk</var> argument
- and runs the <a>decode and enqueue a chunk</a> algorithm with <var>stream</var> and <var>chunk</var>.
+ <li><p>Set <var>stream</var>'s <a for=TextDecoderCommon>decoder</a> to a new instance of
+ <var>encoding</var>'s <a for=/>decoder</a>.
 
- <li><p>Let <var>flushAlgorithm</var> be an algorithm which takes no arguments and runs the
- <a>flush and enqueue</a> algorithm with <var>stream</var>.
+ <li><p>Set <var>stream</var>'s <a for=TextDecoderCommon>I/O queue</a> to a new <a for=/>I/O
+ queue</a>.
+
+ <li><p>Let <var>transformAlgorithm</var> be an algorithm which takes a <var>chunk</var> argument
+ and runs the <a>decode and enqueue a chunk</a> algorithm with <var>stream</var> and
+ <var>chunk</var>.
+
+ <li><p>Let <var>flushAlgorithm</var> be an algorithm which takes no arguments and runs the <a>flush
+ and enqueue</a> algorithm with <var>stream</var>.
 
  <li><p>Let <var>transformStream</var> be a [=new=] {{TransformStream}}.
 
@@ -1885,11 +1894,8 @@ an optional <a for=/>error mode</a> <var>errorMode</var> (default <code>replacem
  <a for="TransformStream/set up"><var ignore>flushAlgorithm</var></a> set to
  <var>flushAlgorithm</var>.
 
- <li><p>Set <var>stream</var>'s <a for=TextDecoderCommon>decoder</a> to a new instance of <var>encoding</var>'s <a for=/>decoder</a>.
-
- <li><p>Set <var>stream</var>'s <a for=TextDecoderCommon>I/O queue</a> to a new <a for=/>I/O queue</a>.
-
- <li><p>Set <var>stream</var>'s <a for=GenericTransformStream>transform</a> to <var>transformStream</var>.
+ <li><p>Set <var>stream</var>'s <a for=GenericTransformStream>transform</a> to
+ <var>transformStream</var>.
 </ol>
 </div>
 

--- a/encoding.bs
+++ b/encoding.bs
@@ -1855,7 +1855,7 @@ constructor steps are:
 
  <li><p>Let <var>ignoreBOM</var> be true if <var>options</var>["{{TextDecoderOptions/ignoreBOM}}"] is true; otherwise false.
 
- <li><p>Call <a>set up a text decoder stream</a> with <a>this</a>, <var>encoding</var>, <var>errorMode</var>, and <var>ignoreBOM</var>.
+ <li><p><a>Set up a text decoder stream</a> with <a>this</a>, <var>encoding</var>, <var>errorMode</var>, and <var>ignoreBOM</var>.
 
 </ol>
 </div>

--- a/encoding.bs
+++ b/encoding.bs
@@ -1851,23 +1851,31 @@ constructor steps are:
 
  <li><p>If <var>encoding</var> is failure or <a>replacement</a>, then <a>throw</a> a {{RangeError}}.
 
- <li><p>Set <a>this</a>'s <a for=TextDecoderCommon>encoding</a> to <var>encoding</var>.
+ <li><p>Let <var>errorMode</var> be <code>fatal</code> if <var>options</var>["{{TextDecoderOptions/fatal}}"] is true; otherwise <code>replacement</code>.
 
- <li><p>If <var>options</var>["{{TextDecoderOptions/fatal}}"] is true, then set <a>this</a>'s
- <a for=TextDecoderCommon>error mode</a> to "<code>fatal</code>".
+ <li><p>Let <var>ignoreBOM</var> be true if <var>options</var>["{{TextDecoderOptions/ignoreBOM}}"] is true; otherwise false.
 
- <li><p>Set <a>this</a>'s <a for=TextDecoderCommon>ignore BOM</a> to
- <var>options</var>["{{TextDecoderOptions/ignoreBOM}}"].
+ <li><p>Call <a>set up a text decoder stream</a> with <a>this</a>, <var>encoding</var>, <var>errorMode</var>, and <var>ignoreBOM</var>.
 
- <li><p>Set <a>this</a>'s <a for=TextDecoderCommon>decoder</a> to a new instance of <a>this</a>'s
- <a for=TextDecoderCommon>encoding</a>'s <a for=/>decoder</a>, and set <a>this</a>'s
- <a for=TextDecoderCommon>I/O queue</a> to a new <a for=/>I/O queue</a>.
+</ol>
+</div>
+
+<div algorithm>
+<p>To <dfn export>set up a text decoder stream</dfn> <var>stream</var>, given an optional [=/encoding=] <var>encoding</var> (default <a>UTF-8</a>),
+an optional <a for=/>error mode</a> <var>errorMode</var> (default <code>replacement</code>), and an optional boolean <var>ignoreBOM</var> (default false), run these steps:
+
+<ol>
+ <li><p>Set <var>stream</var>'s <a for=TextDecoderCommon>encoding</a> to <var>encoding</var>.
+
+ <li><p>Set <var>stream</var>'s <a for=TextDecoderCommon>error mode</a> to <var>errorMode</var>.
+
+ <li><p>Set <var>stream</var>'s <a for=TextDecoderCommon>ignore BOM</a> to <var>ignoreBOM</var>.
 
  <li><p>Let <var>transformAlgorithm</var> be an algorithm which takes a <var>chunk</var> argument
- and runs the <a>decode and enqueue a chunk</a> algorithm with <a>this</a> and <var>chunk</var>.
+ and runs the <a>decode and enqueue a chunk</a> algorithm with <var>stream</var> and <var>chunk</var>.
 
  <li><p>Let <var>flushAlgorithm</var> be an algorithm which takes no arguments and runs the
- <a>flush and enqueue</a> algorithm with <a>this</a>.
+ <a>flush and enqueue</a> algorithm with <var>stream</var>.
 
  <li><p>Let <var>transformStream</var> be a [=new=] {{TransformStream}}.
 
@@ -1877,7 +1885,11 @@ constructor steps are:
  <a for="TransformStream/set up"><var ignore>flushAlgorithm</var></a> set to
  <var>flushAlgorithm</var>.
 
- <li><p>Set <a>this</a>'s <a for=GenericTransformStream>transform</a> to <var>transformStream</var>.
+ <li><p>Set <var>stream</var>'s <a for=TextDecoderCommon>decoder</a> to a new instance of <var>encoding</var>'s <a for=/>decoder</a>.
+
+ <li><p>Set <var>stream</var>'s <a for=TextDecoderCommon>I/O queue</a> to a new <a for=/>I/O queue</a>.
+
+ <li><p>Set <var>stream</var>'s <a for=GenericTransformStream>transform</a> to <var>transformStream</var>.
 </ol>
 </div>
 

--- a/encoding.bs
+++ b/encoding.bs
@@ -1860,10 +1860,11 @@ constructor steps are:
 </div>
 
 <div algorithm>
-<p>To <dfn export>set up a text decoder stream</dfn> <var>stream</var>, given a
-{{TextDecoderStream}} stream, an optional [=/encoding=] <var>encoding</var> (default <a>UTF-8</a>),
-an optional <a for=/>error mode</a> <var>errorMode</var> (default "<code>replacement</code>"), and
-an optional boolean <var>ignoreBOM</var> (default false), run these steps:
+<p>To <dfn export>set up a text decoder stream</dfn> given a {{TextDecoderStream}} object
+<var>stream</var>, an optional [=/encoding=] <var>encoding</var> (default <a>UTF-8</a>), an optional
+<a for=/>error mode</a> <var>errorMode</var> (default "<code>replacement</code>"), and an optional
+boolean <var>ignoreBOM</var> (default false), run these steps:
+
 <ol>
  <li><p><a>Assert</a>: <var>encoding</var> is not <a>replacement</a>.
 


### PR DESCRIPTION
One algo (the constructor) is used by JS, and the "set up" steps is to be used by other specs.

See https://github.com/whatwg/fetch/pull/1862#pullrequestreview-3294323155

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/encoding/364.html" title="Last updated on May 20, 2026, 6:10 PM UTC (833be29)">Preview</a> | <a href="https://whatpr.org/encoding/364/d96155b...833be29.html" title="Last updated on May 20, 2026, 6:10 PM UTC (833be29)">Diff</a>